### PR TITLE
Make `explicitApi` default setting via `configureShared` extension function

### DIFF
--- a/build-logic/src/main/kotlin/-KmpConfigurationExtension.kt
+++ b/build-logic/src/main/kotlin/-KmpConfigurationExtension.kt
@@ -20,6 +20,7 @@ import org.gradle.api.JavaVersion
 
 fun KmpConfigurationExtension.configureShared(
     publish: Boolean = false,
+    explicitApi: Boolean = true,
     action: Action<KmpConfigurationContainerDsl>
 ) {
     configure {
@@ -54,6 +55,12 @@ fun KmpConfigurationExtension.configureShared(
                 dependencies {
                     implementation(kotlin("test"))
                 }
+            }
+        }
+
+        if (explicitApi) {
+            kotlin {
+                explicitApi()
             }
         }
 

--- a/library/md5/build.gradle.kts
+++ b/library/md5/build.gradle.kts
@@ -31,9 +31,5 @@ kmpConfiguration {
                 }
             }
         }
-
-        kotlin {
-            explicitApi()
-        }
     }
 }

--- a/library/sha1/build.gradle.kts
+++ b/library/sha1/build.gradle.kts
@@ -31,9 +31,5 @@ kmpConfiguration {
                 }
             }
         }
-
-        kotlin {
-            explicitApi()
-        }
     }
 }

--- a/library/sha2/sha2-256/build.gradle.kts
+++ b/library/sha2/sha2-256/build.gradle.kts
@@ -31,9 +31,5 @@ kmpConfiguration {
                 }
             }
         }
-
-        kotlin {
-            explicitApi()
-        }
     }
 }

--- a/library/sha2/sha2-512/build.gradle.kts
+++ b/library/sha2/sha2-512/build.gradle.kts
@@ -31,9 +31,5 @@ kmpConfiguration {
                 }
             }
         }
-
-        kotlin {
-            explicitApi()
-        }
     }
 }

--- a/tools/check-publication/build.gradle.kts
+++ b/tools/check-publication/build.gradle.kts
@@ -35,7 +35,7 @@ repositories {
 }
 
 kmpConfiguration {
-    configureShared {
+    configureShared(explicitApi = false) {
         common {
             sourceSetMain {
                 dependencies {

--- a/tools/testing/build.gradle.kts
+++ b/tools/testing/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
 }
 
 kmpConfiguration {
-    configureShared {
+    configureShared(explicitApi = false) {
         common {
             sourceSetMain {
                 dependencies {


### PR DESCRIPTION
Closes #10 