### PR TITLE
Update `kotlincrypto.core:digest` to 0.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 binaryCompat = "0.13.0"
 configuration = "0.1.0-beta02"
-cryptoCore = "0.1.1"
+cryptoCore = "0.2.0"
 encoding = "1.2.1"
 gradleVersions = "0.46.0"
 kotlin = "1.8.10"

--- a/library/sha1/src/commonMain/kotlin/org/kotlincrypto/hash/sha1/SHA1.kt
+++ b/library/sha1/src/commonMain/kotlin/org/kotlincrypto/hash/sha1/SHA1.kt
@@ -28,34 +28,28 @@ public class SHA1: Digest {
 
     @OptIn(InternalKotlinCryptoApi::class)
     public constructor(): super("SHA-1", 64, 20) {
-        x = IntArray(80)
-        state = intArrayOf(
-            1732584193,
-            -271733879,
-            -1732584194,
-            271733878,
-            -1009589776,
-        )
+        this.x = IntArray(80)
+        this.state = intArrayOf(1732584193, -271733879, -1732584194, 271733878, -1009589776)
     }
 
     @OptIn(InternalKotlinCryptoApi::class)
     private constructor(state: DigestState, digest: SHA1): super(state) {
-        x = digest.x.copyOf()
+        this.x = digest.x.copyOf()
         this.state = digest.state.copyOf()
     }
 
     protected override fun copy(state: DigestState): Digest = SHA1(state, this)
 
-    protected override fun compress(buffer: ByteArray) {
+    protected override fun compress(input: ByteArray, offset: Int) {
         val x = x
 
-        var bI = 0
+        var bI = offset
         for (i in 0 until 16) {
             x[i] =
-                ((buffer[bI++].toInt() and 0xff) shl 24) or
-                ((buffer[bI++].toInt() and 0xff) shl 16) or
-                ((buffer[bI++].toInt() and 0xff) shl  8) or
-                ((buffer[bI++].toInt() and 0xff)       )
+                ((input[bI++].toInt() and 0xff) shl 24) or
+                ((input[bI++].toInt() and 0xff) shl 16) or
+                ((input[bI++].toInt() and 0xff) shl  8) or
+                ((input[bI++].toInt() and 0xff)       )
         }
 
         for (i in 16 until 80) {
@@ -112,7 +106,7 @@ public class SHA1: Digest {
         val size = bufferOffset + 1
         if (size > 56) {
             buffer.fill(0, size, blockSize())
-            compress(buffer)
+            compress(buffer, 0)
             buffer.fill(0, 0, size)
         } else {
             buffer.fill(0, size, 56)
@@ -127,7 +121,7 @@ public class SHA1: Digest {
         buffer[62] = (bitLength ushr  8).toByte()
         buffer[63] = (bitLength        ).toByte()
 
-        compress(buffer)
+        compress(buffer, 0)
 
         val a = state[0]
         val b = state[1]

--- a/library/sha2/api/sha2.api
+++ b/library/sha2/api/sha2.api
@@ -1,7 +1,7 @@
 public abstract class org/kotlincrypto/hash/sha2/Bit32Digest : org/kotlincrypto/core/Digest {
 	public synthetic fun <init> (IIIIIIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Lorg/kotlincrypto/core/internal/DigestState;Lorg/kotlincrypto/hash/sha2/Bit32Digest;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	protected final fun compress ([B)V
+	protected final fun compress ([BI)V
 	protected final fun digest (JI[B)[B
 	protected abstract fun out (IIIIIIII)[B
 	protected final fun resetDigest ()V
@@ -18,7 +18,7 @@ public abstract class org/kotlincrypto/hash/sha2/Bit64Digest : org/kotlincrypto/
 	protected field h7 J
 	public synthetic fun <init> (ILjava/lang/Integer;JJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Lorg/kotlincrypto/core/internal/DigestState;Lorg/kotlincrypto/hash/sha2/Bit64Digest;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	protected final fun compress ([B)V
+	protected final fun compress ([BI)V
 	protected final fun digest (JI[B)[B
 	protected abstract fun out (JJJJJJJJ)[B
 	protected final fun resetDigest ()V

--- a/library/sha2/src/commonMain/kotlin/org/kotlincrypto/hash/sha2/Bit32Digest.kt
+++ b/library/sha2/src/commonMain/kotlin/org/kotlincrypto/hash/sha2/Bit32Digest.kt
@@ -90,16 +90,16 @@ public sealed class Bit32Digest: Digest {
         this.state = digest.state.copyOf()
     }
 
-    protected final override fun compress(buffer: ByteArray) {
+    protected final override fun compress(input: ByteArray, offset: Int) {
         val x = x
 
-        var bI = 0
+        var bI = offset
         for (i in 0 until 16) {
             x[i] =
-                ((buffer[bI++].toInt() and 0xff) shl 24) or
-                ((buffer[bI++].toInt() and 0xff) shl 16) or
-                ((buffer[bI++].toInt() and 0xff) shl  8) or
-                ((buffer[bI++].toInt() and 0xff)       )
+                ((input[bI++].toInt() and 0xff) shl 24) or
+                ((input[bI++].toInt() and 0xff) shl 16) or
+                ((input[bI++].toInt() and 0xff) shl  8) or
+                ((input[bI++].toInt() and 0xff)       )
         }
 
         for (i in 16 until 64) {
@@ -171,7 +171,7 @@ public sealed class Bit32Digest: Digest {
         val size = bufferOffset + 1
         if (size > 56) {
             buffer.fill(0, size, 64)
-            compress(buffer)
+            compress(buffer, 0)
             buffer.fill(0, 0, size)
         } else {
             buffer.fill(0, size, 56)
@@ -186,7 +186,7 @@ public sealed class Bit32Digest: Digest {
         buffer[62] = (bitLength ushr  8).toByte()
         buffer[63] = (bitLength        ).toByte()
 
-        compress(buffer)
+        compress(buffer, 0)
 
         return out(
            a = state[0],

--- a/library/sha2/src/commonMain/kotlin/org/kotlincrypto/hash/sha2/Bit64Digest.kt
+++ b/library/sha2/src/commonMain/kotlin/org/kotlincrypto/hash/sha2/Bit64Digest.kt
@@ -108,20 +108,20 @@ public sealed class Bit64Digest: Digest {
         this.state = digest.state.copyOf()
     }
 
-    protected final override fun compress(buffer: ByteArray) {
+    protected final override fun compress(input: ByteArray, offset: Int) {
         val x = x
 
-        var bI = 0
+        var bI = offset
         for (i in 0 until 16) {
             x[i] =
-                ((buffer[bI++].toLong() and 0xff) shl 56) or
-                ((buffer[bI++].toLong() and 0xff) shl 48) or
-                ((buffer[bI++].toLong() and 0xff) shl 40) or
-                ((buffer[bI++].toLong() and 0xff) shl 32) or
-                ((buffer[bI++].toLong() and 0xff) shl 24) or
-                ((buffer[bI++].toLong() and 0xff) shl 16) or
-                ((buffer[bI++].toLong() and 0xff) shl  8) or
-                ((buffer[bI++].toLong() and 0xff)       )
+                ((input[bI++].toLong() and 0xff) shl 56) or
+                ((input[bI++].toLong() and 0xff) shl 48) or
+                ((input[bI++].toLong() and 0xff) shl 40) or
+                ((input[bI++].toLong() and 0xff) shl 32) or
+                ((input[bI++].toLong() and 0xff) shl 24) or
+                ((input[bI++].toLong() and 0xff) shl 16) or
+                ((input[bI++].toLong() and 0xff) shl  8) or
+                ((input[bI++].toLong() and 0xff)       )
         }
 
         for (i in 16 until 80) {
@@ -181,7 +181,7 @@ public sealed class Bit64Digest: Digest {
         val size = bufferOffset + 1
         if (size > 112) {
             buffer.fill(0, size, 128)
-            compress(buffer)
+            compress(buffer, 0)
             buffer.fill(0, 0, size)
         } else {
             buffer.fill(0, size, 120)
@@ -196,7 +196,7 @@ public sealed class Bit64Digest: Digest {
         buffer[126] = (bitLength ushr  8).toByte()
         buffer[127] = (bitLength        ).toByte()
 
-        compress(buffer)
+        compress(buffer, 0)
 
         return out(
             a = state[0],

--- a/tools/testing/src/jvmMain/kotlin/org/kotlincrypto/hash/TestJvmDigest.kt
+++ b/tools/testing/src/jvmMain/kotlin/org/kotlincrypto/hash/TestJvmDigest.kt
@@ -53,7 +53,7 @@ class TestJvmDigest: Digest {
 
     override fun copy(state: DigestState): Digest = TestJvmDigest(state, this)
 
-    override fun compress(buffer: ByteArray) { delegate.update(buffer) }
+    override fun compress(input: ByteArray, offset: Int) { delegate.update(input, offset, blockSize()) }
 
     override fun digest(bitLength: Long, bufferOffset: Int, buffer: ByteArray): ByteArray {
         delegate.update(buffer, 0, bufferOffset)


### PR DESCRIPTION
Closes #27 

This PR:
- Updates `kotlincrypto.core:digest` to version `0.2.0`
- Updates internal `Digest.compress` methods with API changes