### PR TITLE
Add new test to exercise block size bounds for input

### DIFF
--- a/library/md5/src/commonTest/kotlin/org/kotlincrypto/hash/md/MD5UnitTest.kt
+++ b/library/md5/src/commonTest/kotlin/org/kotlincrypto/hash/md/MD5UnitTest.kt
@@ -22,12 +22,18 @@ import kotlin.test.Test
 open class MD5UnitTest: DigestUnitTest() {
     override val digest: Digest = MD5()
     final override val expectedResetHash: String = "d41d8cd98f00b204e9800998ecf8427e"
+    final override val expectedMultiBlockHash: String = "50c1f97db49ceb134f59948851424e78"
     final override val expectedUpdateSmallHash: String = "a0b0f0ae132fe7c79c678fddda4309ba"
     final override val expectedUpdateMediumHash: String = "9fcb20905157e9afaa264a1e26762308"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha1/src/commonTest/kotlin/org/kotlincrypto/hash/sha1/SHA1UnitTest.kt
+++ b/library/sha1/src/commonTest/kotlin/org/kotlincrypto/hash/sha1/SHA1UnitTest.kt
@@ -22,12 +22,18 @@ import kotlin.test.Test
 open class SHA1UnitTest: DigestUnitTest() {
     override val digest: Digest = SHA1()
     final override val expectedResetHash: String = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+    final override val expectedMultiBlockHash: String = "c163c160b4810440865e6c60a08d8f1e6bd1b946"
     final override val expectedUpdateSmallHash: String = "3e87f2fb5366045ef4fcaf3a845554d16b36f69d"
     final override val expectedUpdateMediumHash: String = "c0e5c75fba36a5a24ad475ac2321c581aea8008e"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha2/src/commonTest/kotlin/org/kotlincrypto/hash/sha2/SHA224UnitTest.kt
+++ b/library/sha2/src/commonTest/kotlin/org/kotlincrypto/hash/sha2/SHA224UnitTest.kt
@@ -22,12 +22,18 @@ import kotlin.test.Test
 open class SHA224UnitTest: DigestUnitTest() {
     override val digest: Digest = SHA224()
     final override val expectedResetHash: String = "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f"
+    final override val expectedMultiBlockHash: String = "1ad34335a940dcc00053422a06a233445ce0f7b511481d3416e0f539"
     final override val expectedUpdateSmallHash: String = "bda63b682436fa6767ad866fb78c48da5da268a80e49fa91b2a1349d"
     final override val expectedUpdateMediumHash: String = "190464776331b2a2d618bb82e3567c4de96c7d23bd7ea0376d8cabc8"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha2/src/commonTest/kotlin/org/kotlincrypto/hash/sha2/SHA256UnitTest.kt
+++ b/library/sha2/src/commonTest/kotlin/org/kotlincrypto/hash/sha2/SHA256UnitTest.kt
@@ -22,12 +22,18 @@ import kotlin.test.Test
 open class SHA256UnitTest: DigestUnitTest() {
     override val digest: Digest = SHA256()
     final override val expectedResetHash: String = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    final override val expectedMultiBlockHash: String = "8aab5b8b2db16c3fa385d6b16c163571d4c1a24b46b1d0a93dd172dcbcbb470f"
     final override val expectedUpdateSmallHash: String = "9e5271a0c245b7e73d5f7936a1c6897cc9f7e844a62a2e0dcc97fdd933295853"
     final override val expectedUpdateMediumHash: String = "b04e2d0ca3c0bd2027bbb58e9267ffb0f526953dd319545a89faf9f3e3b6d2fa"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha2/src/commonTest/kotlin/org/kotlincrypto/hash/sha2/SHA384UnitTest.kt
+++ b/library/sha2/src/commonTest/kotlin/org/kotlincrypto/hash/sha2/SHA384UnitTest.kt
@@ -22,12 +22,18 @@ import kotlin.test.Test
 open class SHA384UnitTest: DigestUnitTest() {
     override val digest: Digest = SHA384()
     final override val expectedResetHash: String = "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
+    final override val expectedMultiBlockHash: String = "5fb00b191cdfba166170ac5c0004d8c4158614c860f40fd6fbb17e4a69586e324e459ca3975055421423e15b45750e53"
     final override val expectedUpdateSmallHash: String = "7a806422b07e7d139dc6201efafeb7fecaafeca412ed5ad1fae08e48ac14bdbfd75466c7f89a0d4425563522837dc99b"
     final override val expectedUpdateMediumHash: String = "196631c49831ab81a8002873897234945df585a0f58ceca0bd9357ccdf4eb4a9f30f5845001c7b6ac41816c0a12517d4"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha2/src/commonTest/kotlin/org/kotlincrypto/hash/sha2/SHA512UnitTest.kt
+++ b/library/sha2/src/commonTest/kotlin/org/kotlincrypto/hash/sha2/SHA512UnitTest.kt
@@ -22,12 +22,18 @@ import kotlin.test.Test
 open class SHA512UnitTest: DigestUnitTest() {
     override val digest: Digest = SHA512()
     final override val expectedResetHash: String = "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+    final override val expectedMultiBlockHash: String = "6f843bbf4b7e485ac572f211eb80cc284a877bbc5e6bcd1579a8b099cbc17aff2900080d4422e477615771a583e13c1cb9f88ba0acad81932bf69830ff8d4f58"
     final override val expectedUpdateSmallHash: String = "6f23b0a36ea92b792dc6b19739ea4b9ee565478e3107016bf7749898b963b1247cdccf39f63f97703a001e2f97a859d31f39d5c277e0594ad06677242ed93fd8"
     final override val expectedUpdateMediumHash: String = "47689826e2d98e51e325c1b66723fa08fde6e894b8fe1bc7f1ae2860d9c709776f77bfca856a0688c29a275c72d8738d6afc62e808ac8f01ef29a29381078719"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha2/src/commonTest/kotlin/org/kotlincrypto/hash/sha2/SHA512_224UnitTest.kt
+++ b/library/sha2/src/commonTest/kotlin/org/kotlincrypto/hash/sha2/SHA512_224UnitTest.kt
@@ -23,12 +23,18 @@ import kotlin.test.Test
 open class SHA512_224UnitTest: DigestUnitTest() {
     override val digest: Digest = SHA512_224()
     final override val expectedResetHash: String = "6ed0dd02806fa89e25de060c19d3ac86cabb87d6a0ddd05c333b84f4"
+    final override val expectedMultiBlockHash: String = "66ae2573cde87f96acc5aa48a58eb5d4bf36246671451e1b4830086a"
     final override val expectedUpdateSmallHash: String = "d45c8e42b7a6a28123e5026f8d55acdd9b2e8738e4b65fe65c86f5c4"
     final override val expectedUpdateMediumHash: String = "ac0a3c03de7ca29bcb05f1d5f1ad074da0002bcda21b05637c25099f"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha2/src/commonTest/kotlin/org/kotlincrypto/hash/sha2/SHA512_256UnitTest.kt
+++ b/library/sha2/src/commonTest/kotlin/org/kotlincrypto/hash/sha2/SHA512_256UnitTest.kt
@@ -23,12 +23,18 @@ import kotlin.test.Test
 open class SHA512_256UnitTest: DigestUnitTest() {
     override val digest: Digest = SHA512_256()
     final override val expectedResetHash: String = "c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a"
+    final override val expectedMultiBlockHash: String = "c870620b1b7f4b774e62e1e38b90b3605c3281eb00e28fbc71ed77150de26aa4"
     final override val expectedUpdateSmallHash: String = "49a4cf33a539e4819ff6ef478ef24f307379efb33b296e97a19497135314d1e0"
     final override val expectedUpdateMediumHash: String = "85fcfb43e87203b9c795e2251e2490d1f3db3a7679cb0f6ebada4104bcc34fa9"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/CSHAKE128UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/CSHAKE128UnitTest.kt
@@ -29,12 +29,18 @@ open class CSHAKE128UnitTest: DigestUnitTest() {
     protected val S = "Test CSHAKE".encodeToByteArray()
     override val digest: Digest = CSHAKE128(null, null)
     override val expectedResetHash: String = "7f9c2ba4e88f827d616045507605853ed73b8093f6efbc88eb1a6eacfa66ef26"
+    override val expectedMultiBlockHash: String = "e1b0a326f24f23ef3a861fef0c2835b489c533e58b898f4d0ccf873ea03cfa40"
     override val expectedUpdateSmallHash: String = "0b33a664b281d9a38638832fd314444c2fa5865072e61505d0776c5cdd322ca3"
     override val expectedUpdateMediumHash: String = "9bf64f28a64f294769abd18b8903820453c9f31fe1bf620f95dede8f0b5d9f56"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/CSHAKE128_NS_UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/CSHAKE128_NS_UnitTest.kt
@@ -23,6 +23,7 @@ import kotlin.test.Test
 open class CSHAKE128_NS_UnitTest: CSHAKE128UnitTest() {
     override val digest: Digest = CSHAKE128(N, S)
     final override val expectedResetHash: String = "91d6b4ecfd7f295f8e11a2a738a294bb1e4f9fa5aec7834e37ac97c81c41bf8e"
+    final override val expectedMultiBlockHash: String = "18d36a7b3fa97a34d705afe76baffeac4d7c7d13b9c3da5220864d4f75c1478a"
     final override val expectedUpdateSmallHash: String = "ba9a9ecb49bac859073f141aa782aa3b0f2006183819b0b2aacf52bbc77b85aa"
     final override val expectedUpdateMediumHash: String = "bcc7b6cb50fe65aa14bbc050d973d87c3dad221f402f6114c1c22c643ae966f1"
 

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/CSHAKE128_N_UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/CSHAKE128_N_UnitTest.kt
@@ -23,6 +23,7 @@ import kotlin.test.Test
 open class CSHAKE128_N_UnitTest: CSHAKE128UnitTest() {
     override val digest: Digest = CSHAKE128(N, null)
     final override val expectedResetHash: String = "63e5b592ba16aef96e22c02f995e04421df9ec14be1b5e82d4da9af10ff2a8c0"
+    final override val expectedMultiBlockHash: String = "5584236dfd97c2a10fe7431c3b17a2c02b097aaa6921be1c9ad214d2e16e5d1f"
     final override val expectedUpdateSmallHash: String = "d72243337762656b8d1d48f0ba502468590745e825f6fcfb5c031ff458c2a1e6"
     final override val expectedUpdateMediumHash: String = "8110a0f4e6886075dc1d11372a3760868ca6b719cace7a95b75a69583021637f"
 

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/CSHAKE128_S_UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/CSHAKE128_S_UnitTest.kt
@@ -23,6 +23,7 @@ import kotlin.test.Test
 open class CSHAKE128_S_UnitTest: CSHAKE128UnitTest() {
     override val digest: Digest = CSHAKE128(null, S)
     final override val expectedResetHash: String = "4f3047dee03c3b698f2b6da12bffe7ff89bb5c5bb0bc4e4a8a2ba77c12d70af6"
+    final override val expectedMultiBlockHash: String = "ce10a0013b4d274a8dd25a96ad62aef8f5e0e99fcb62d5bff50405b5b76660a5"
     final override val expectedUpdateSmallHash: String = "42de220e99553116a60d6316540774d2e9984419cffe5ac2fc62cf0b41227ac3"
     final override val expectedUpdateMediumHash: String = "1379ca33af3ec1032c51eed4c3996c18f90e3121d8ce8ef36323fa159045472f"
 

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/CSHAKE256UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/CSHAKE256UnitTest.kt
@@ -29,12 +29,18 @@ open class CSHAKE256UnitTest: DigestUnitTest() {
     protected val S = "Test CSHAKE".encodeToByteArray()
     override val digest: Digest = CSHAKE256(null, null)
     override val expectedResetHash: String = "46b9dd2b0ba88d13233b3feb743eeb243fcd52ea62b81b82b50c27646ed5762fd75dc4ddd8c0f200cb05019d67b592f6fc821c49479ab48640292eacb3b7c4be"
+    override val expectedMultiBlockHash: String = "2cc1a8692a767fe3122b42e66567694729325de26b01e1e1acfba8b47d79f8e550bcd93e17bdcea0d25b1040f000a6895cba15fb5631a10a5817dacd22c642cd"
     override val expectedUpdateSmallHash: String = "030f4a342728ddc61799a29afb8f904a3276e04ead3c3fb0f3ef2fb2ec9c85a3cd87c6549a17c727c3d544def386d005751a06cc2a96c489b48ce270762e7794"
     override val expectedUpdateMediumHash: String = "42dacceebb007046252e70a319ab2e162cd0ffb3b3e6fcf0e865fbf3763fa7325d4add48be7917c2bfb09e6fa0a197cbece5a1ee5b7e1a554b514197e84b7f46"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/CSHAKE256_NS_UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/CSHAKE256_NS_UnitTest.kt
@@ -22,6 +22,7 @@ import kotlin.test.Test
 open class CSHAKE256_NS_UnitTest: CSHAKE256UnitTest() {
     override val digest: Digest = CSHAKE256(N, S)
     final override val expectedResetHash: String = "2a46f1df815e8cd2f645df371d97989fa31ff99c80731c1f6ec2d3e48b183193524742eb87c5007edd1549feaaddbff2623cd16f3b5f8506e438d6aad8476107"
+    final override val expectedMultiBlockHash: String = "5077045db9148c7ee4f665c50e3aeb49d032e4058dbb5a6f0791c03cde3c44c108d30403ca2626294163ff81edeb7f674ed709505c4b25c345b84042a82b40e0"
     final override val expectedUpdateSmallHash: String = "69269d2e388a5b116b70ed4d8ce8eb5f964e8236d25e7e29bbf251f990fc99036ab170a1ba47eeca03581741b420167bc806634af4387753eaac0a77e6fa06e4"
     final override val expectedUpdateMediumHash: String = "2d555623df2198f3fd36f5f5a79190eb06b6ce38bfe10cc9f1ff86542a2511babe79fd1b0c0d0b6d9d9941a131a69a4ea90483e7dc592848e03a0703f112d717"
 

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/CSHAKE256_N_UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/CSHAKE256_N_UnitTest.kt
@@ -22,6 +22,7 @@ import kotlin.test.Test
 open class CSHAKE256_N_UnitTest: CSHAKE256UnitTest() {
     override val digest: Digest = CSHAKE256(N, null)
     final override val expectedResetHash: String = "bee8b14df0e3c77030458609ed34cea99206ced74a5fe6bf9d3e72852ec7ca5647cef12bcb27dd9cd3fcd604fd7f1daff8ab6091d48e9f5c101d3e99dfc57e17"
+    final override val expectedMultiBlockHash: String = "717a67d51fc606bc0caf03568a2be81d22b9179f4aafee1a9dbc14dc8d49910283eb64f072162fe6ce1a043ff5013a99a3334cb77bf078690950692af9bd94dc"
     final override val expectedUpdateSmallHash: String = "44c2e60abb32ba2fe774bc634bf9dc5fafc86382b90f3181d52a412a6d07ec6da9eddf23b27d232cba7832e8b81c6be65590a3b3c332b41c350629815acc2ee9"
     final override val expectedUpdateMediumHash: String = "9d1ad68945f0b9808308cb35bb043e231dfda40b0ca8f3214d43c34b007bc1777ee4517f178db034a60743d317c6316880e608f3362d586184f3babef64c0eee"
 

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/CSHAKE256_S_UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/CSHAKE256_S_UnitTest.kt
@@ -22,6 +22,7 @@ import kotlin.test.Test
 open class CSHAKE256_S_UnitTest: CSHAKE256UnitTest() {
     override val digest: Digest = CSHAKE256(null, S)
     final override val expectedResetHash: String = "3d79db7f3aaef4585ef784a9765ded61b069986184806de469e73fd3aaa854aaabd507ed16f87c0cb54e4f3cfbd9da9241476220f47a04eb4da29f514df65627"
+    final override val expectedMultiBlockHash: String = "7e15ee688a1d7f43a2ad239d6045bcb07ab3c8a7c4ca4b6a9b8d2cc98ed7864d8213c98fb1dfb6a67a375d5492d789b1b9fa0e78ba297999467161c9030fa70a"
     final override val expectedUpdateSmallHash: String = "bf7058871040867ebe9d2de8714273c4068d85704d959160914c24c4061654ff5f39759cc4af9480bf75b4d7e9e68031159aec1b1ebee2ef0ffc83c7970a9b0a"
     final override val expectedUpdateMediumHash: String = "2430b7216231190dc13970c1fb1d8b4d64c6f2e02e6b0392d6a491bebba8668b6d0de4500e949c20d6986f069e52a1cd04a694a00021fa11e42e92d493a16f78"
 

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/Keccak224UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/Keccak224UnitTest.kt
@@ -22,12 +22,18 @@ import org.kotlincrypto.hash.DigestUnitTest
 open class Keccak224UnitTest: DigestUnitTest() {
     override val digest: Digest = Keccak224()
     final override val expectedResetHash: String = "f71837502ba8e10837bdd8d365adb85591895602fc552b48b7390abd"
+    final override val expectedMultiBlockHash: String = "1bd802cff39a23de7feca1555ac89bd9c8ac45e155aee4e277bdbf72"
     final override val expectedUpdateSmallHash: String = "20f33d3e558dc42e091d6181a8cd93be377faec004599ae2789d23d0"
     final override val expectedUpdateMediumHash: String = "68cba72dfecc8c2c925ea08f2d41a4567fe79d8e98dd2e583a2524ee"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/Keccak256UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/Keccak256UnitTest.kt
@@ -22,12 +22,18 @@ import org.kotlincrypto.hash.DigestUnitTest
 open class Keccak256UnitTest: DigestUnitTest() {
     override val digest: Digest = Keccak256()
     final override val expectedResetHash: String = "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+    final override val expectedMultiBlockHash: String = "157e0f9078dd4e59644d0e55c8377bb1079388e330cf30ec17a5aabaedf96ed1"
     final override val expectedUpdateSmallHash: String = "8da7db9b1b86176084b942444756fd50f17afd89a16f9df1de1d1a0a8903c583"
     final override val expectedUpdateMediumHash: String = "06c89b5c8b7f8e6ad6480b29b50180cbfc92c3c2c9b2954833289e695c9eec0b"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/Keccak384UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/Keccak384UnitTest.kt
@@ -22,12 +22,18 @@ import org.kotlincrypto.hash.DigestUnitTest
 open class Keccak384UnitTest: DigestUnitTest() {
     override val digest: Digest = Keccak384()
     final override val expectedResetHash: String = "2c23146a63a29acf99e73b88f8c24eaa7dc60aa771780ccc006afbfa8fe2479b2dd2b21362337441ac12b515911957ff"
+    final override val expectedMultiBlockHash: String = "8964fd73276b79b9c50c27b75f32d5171b30a47d5fb7c4508b4866175df80df05a17c4ce07c4f51ac284280570346527"
     final override val expectedUpdateSmallHash: String = "b72bbe6eb5e663354b10cbdb744141319b2fc7eda91da087291459a26f17e513b7ba689840afb92c4246b05a14d1b78f"
     final override val expectedUpdateMediumHash: String = "288cc2eae0bc30cddf7be0b09cc658146d4b00d40009dc5ac11feafed46a4d00c9a5bf3ed77e29d28a0eb2cb8e202679"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/Keccak512UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/Keccak512UnitTest.kt
@@ -22,12 +22,18 @@ import org.kotlincrypto.hash.DigestUnitTest
 open class Keccak512UnitTest: DigestUnitTest() {
     override val digest: Digest = Keccak512()
     final override val expectedResetHash: String = "0eab42de4c3ceb9235fc91acffe746b29c29a8c366b7c60e4e67c466f36a4304c00fa9caf9d87976ba469bcbe06713b435f091ef2769fb160cdab33d3670680e"
+    final override val expectedMultiBlockHash: String = "1b754964c676835605b427de53e88fb0051343f839467ed4581b5c33cc2b929534d5a8a09caced753e3dfbecacf1591ba012340064b402699089e58fc1be3ef4"
     final override val expectedUpdateSmallHash: String = "b9796be8d17dd0462312a5fdaa14cbc3553f2881be79c4e0ee36ee7af32836e1daea9b8b97896fef67679e0106e121fda16611707fe8de3c9008188ecbd1640d"
     final override val expectedUpdateMediumHash: String = "00b9eb87c814240a661c432680aa3b2d33f7d249acd54dd52b63503e746b2e510e7f529f14acf9b25863895228e12f64f721836adbaa1b6b9d088b639aca7225"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/SHA3_224UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/SHA3_224UnitTest.kt
@@ -23,12 +23,18 @@ import org.kotlincrypto.hash.DigestUnitTest
 open class SHA3_224UnitTest: DigestUnitTest() {
     override val digest: Digest = SHA3_224()
     final override val expectedResetHash: String = "6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7"
+    final override val expectedMultiBlockHash: String = "b21e3044cc8b1396fc53d9f9150b47294d8a670a31fb09486db70cc3"
     final override val expectedUpdateSmallHash: String = "d167147af05bbf46f5c730dc69fad8ed64e2afa900b8e4ebde4d8e00"
     final override val expectedUpdateMediumHash: String = "ac05fe6c9eedb6c000204443aeb3c2c99d38d20b4bd97c315d814202"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/SHA3_256UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/SHA3_256UnitTest.kt
@@ -23,12 +23,18 @@ import org.kotlincrypto.hash.DigestUnitTest
 open class SHA3_256UnitTest: DigestUnitTest() {
     override val digest: Digest = SHA3_256()
     final override val expectedResetHash: String = "a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a"
+    final override val expectedMultiBlockHash: String = "074ba726c73760bfcd4b177b3a2c0f0a26b26c165270ffd5f03e6d970650a0fa"
     final override val expectedUpdateSmallHash: String = "b41380a98cec55fee0785b76c6dbe5500a6f7b9d4ede7de182acb5d0dc1e7e59"
     final override val expectedUpdateMediumHash: String = "aecf3132dd50201f8ea6959ebed69cff09ae5cb2e1fed97bb7cd4ff8ae4e73eb"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/SHA3_384UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/SHA3_384UnitTest.kt
@@ -23,12 +23,18 @@ import org.kotlincrypto.hash.DigestUnitTest
 open class SHA3_384UnitTest: DigestUnitTest() {
     override val digest: Digest = SHA3_384()
     final override val expectedResetHash: String = "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004"
+    final override val expectedMultiBlockHash: String = "73426556798b293b15ce115cf2a9cfdc8355dc944337066fd29970d8caa7995b0dd4905d472258e80097078ebb350c61"
     final override val expectedUpdateSmallHash: String = "1b7961192a99b13e07f56875fd017196ad097821206f8d7e4f0703d6cae969937370a35933c6c86d8a3fcce6b0eacfc0"
     final override val expectedUpdateMediumHash: String = "828cc3e1f627b9e49213b8cc14f2454c34ac04b222473f5f34e5b0e201506b5b529957d3b83341ed297c29d069e0c9d5"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/SHA3_512UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/SHA3_512UnitTest.kt
@@ -23,12 +23,18 @@ import org.kotlincrypto.hash.DigestUnitTest
 open class SHA3_512UnitTest: DigestUnitTest() {
     override val digest: Digest = SHA3_512()
     final override val expectedResetHash: String = "a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26"
+    final override val expectedMultiBlockHash: String = "31ef1874aa60198b5ae36adb3a700751461ab6af3ad1f2dac95ccfe0d93f4a1b1b36122414f3d819d5d85cfee2789dd3793af6166892009682e893a9e19a9716"
     final override val expectedUpdateSmallHash: String = "c264245a4e9ed0b44ff30465ecb32cc03813fc1d14fc9baf67c65c65ce815bb594aeabd4b20eac6f24090537f0e667e00eb3e2a3e6ad63a54962860c180f45b0"
     final override val expectedUpdateMediumHash: String = "b4f4480828d0e2e4bfdf2e39671fa296e355457e7db585a26dee0d0201bc589f24a6342ede76eb345b35b504f196967044c53223722e3330bee12f346dea4a2c"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/SHAKE128UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/SHAKE128UnitTest.kt
@@ -22,12 +22,18 @@ import org.kotlincrypto.hash.DigestUnitTest
 open class SHAKE128UnitTest: DigestUnitTest() {
     override val digest: Digest = SHAKE128()
     final override val expectedResetHash: String = "7f9c2ba4e88f827d616045507605853ed73b8093f6efbc88eb1a6eacfa66ef26"
+    final override val expectedMultiBlockHash: String = "e1b0a326f24f23ef3a861fef0c2835b489c533e58b898f4d0ccf873ea03cfa40"
     final override val expectedUpdateSmallHash: String = "0b33a664b281d9a38638832fd314444c2fa5865072e61505d0776c5cdd322ca3"
     final override val expectedUpdateMediumHash: String = "9bf64f28a64f294769abd18b8903820453c9f31fe1bf620f95dede8f0b5d9f56"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/SHAKE256UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/SHAKE256UnitTest.kt
@@ -22,12 +22,18 @@ import org.kotlincrypto.hash.DigestUnitTest
 open class SHAKE256UnitTest: DigestUnitTest() {
     override val digest: Digest = SHAKE256()
     final override val expectedResetHash: String = "46b9dd2b0ba88d13233b3feb743eeb243fcd52ea62b81b82b50c27646ed5762fd75dc4ddd8c0f200cb05019d67b592f6fc821c49479ab48640292eacb3b7c4be"
+    final override val expectedMultiBlockHash: String = "2cc1a8692a767fe3122b42e66567694729325de26b01e1e1acfba8b47d79f8e550bcd93e17bdcea0d25b1040f000a6895cba15fb5631a10a5817dacd22c642cd"
     final override val expectedUpdateSmallHash: String = "030f4a342728ddc61799a29afb8f904a3276e04ead3c3fb0f3ef2fb2ec9c85a3cd87c6549a17c727c3d544def386d005751a06cc2a96c489b48ce270762e7794"
     final override val expectedUpdateMediumHash: String = "42dacceebb007046252e70a319ab2e162cd0ffb3b3e6fcf0e865fbf3763fa7325d4add48be7917c2bfb09e6fa0a197cbece5a1ee5b7e1a554b514197e84b7f46"
 
     @Test
     final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
     }
 
     @Test

--- a/tools/testing/src/commonMain/kotlin/org/kotlincrypto/hash/DigestUnitTest.kt
+++ b/tools/testing/src/commonMain/kotlin/org/kotlincrypto/hash/DigestUnitTest.kt
@@ -22,12 +22,30 @@ import kotlin.test.assertNotEquals
 
 abstract class DigestUnitTest: HashUnitTest() {
     abstract val digest: Digest
+    abstract val expectedMultiBlockHash: String
 
     open fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
         updateSmall(digest)
         digest.reset()
         val actual = digest.digest().encodeToString(TestData.base16)
         assertEquals(expectedResetHash, actual)
+    }
+
+    open fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        val sizes = (digest.blockSize() - 10)..(digest.blockSize() + 10)
+
+        val outputs = mutableListOf<ByteArray>()
+        for (size in sizes) {
+            val digested = digest.digest(TestData.BYTES_MEDIUM.copyOf(size))
+            outputs.add(digested)
+        }
+
+        for (output in outputs) {
+            digest.update(output)
+        }
+
+        val actual = digest.digest().encodeToString(TestData.base16)
+        assertEquals(expectedMultiBlockHash, actual)
     }
 
     open fun givenDigest_whenUpdatedSmall_thenDigestDigestReturnsExpected() {


### PR DESCRIPTION
Adds unit test for digesting bytes from `blockSize - 10` to `blockSize + 10`