### PR TITLE
Add `SHA3` derived hash functions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,13 @@ allprojects {
 
     repositories {
         mavenCentral()
+
+        if (version.toString().endsWith("-SNAPSHOT")) {
+            // Only allow snapshot dependencies for non-release versions.
+            // This would cause a build failure if attempting to make a release
+            // while depending on a -SNAPSHOT version (such as core).
+            maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+        }
     }
 
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 binaryCompat = "0.13.0"
 bouncyCastle = "1.72"
 configuration = "0.1.0-beta02"
-cryptoCore = "0.2.3"
+cryptoCore = "0.2.4-SNAPSHOT"
 encoding = "1.2.1"
 endians = "0.1.0"
 gradleVersions = "0.46.0"

--- a/library/sha3/api/sha3.api
+++ b/library/sha3/api/sha3.api
@@ -45,12 +45,43 @@ public abstract class org/kotlincrypto/hash/sha3/KeccakDigest : org/kotlincrypto
 	public synthetic fun <init> (Ljava/lang/String;IIBLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Lorg/kotlincrypto/core/internal/DigestState;Lorg/kotlincrypto/hash/sha3/KeccakDigest;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected final fun compress ([BI)V
-	protected final fun digest (JI[B)[B
+	protected fun digest (JI[B)[B
 	protected fun extract (Lorg/kotlincrypto/sponges/keccak/F1600;[BIIJ)[B
 	protected fun resetDigest ()V
 }
 
 protected final class org/kotlincrypto/hash/sha3/KeccakDigest$Companion {
+}
+
+public abstract class org/kotlincrypto/hash/sha3/ParallelDigest : org/kotlincrypto/hash/sha3/SHAKEDigest {
+	public synthetic fun <init> (Lorg/kotlincrypto/core/internal/DigestState;Lorg/kotlincrypto/hash/sha3/ParallelDigest;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> ([BIZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected final fun digest (JI[B)[B
+	protected final fun resetDigest ()V
+	protected final fun updateDigest (B)V
+	protected final fun updateDigest ([BII)V
+}
+
+public final class org/kotlincrypto/hash/sha3/ParallelHash128 : org/kotlincrypto/hash/sha3/ParallelDigest {
+	public static final field Companion Lorg/kotlincrypto/hash/sha3/ParallelHash128$Companion;
+	public fun <init> ([BI)V
+	public synthetic fun <init> ([BIZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun xOf ([BI)Lorg/kotlincrypto/core/Xof;
+}
+
+public final class org/kotlincrypto/hash/sha3/ParallelHash128$Companion : org/kotlincrypto/hash/sha3/SHAKEDigest$SHAKEXofFactory {
+	public final fun xOf ([BI)Lorg/kotlincrypto/core/Xof;
+}
+
+public final class org/kotlincrypto/hash/sha3/ParallelHash256 : org/kotlincrypto/hash/sha3/ParallelDigest {
+	public static final field Companion Lorg/kotlincrypto/hash/sha3/ParallelHash256$Companion;
+	public fun <init> ([BI)V
+	public synthetic fun <init> ([BIZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun xOf ([BI)Lorg/kotlincrypto/core/Xof;
+}
+
+public final class org/kotlincrypto/hash/sha3/ParallelHash256$Companion : org/kotlincrypto/hash/sha3/SHAKEDigest$SHAKEXofFactory {
+	public final fun xOf ([BI)Lorg/kotlincrypto/core/Xof;
 }
 
 public final class org/kotlincrypto/hash/sha3/SHA3_224 : org/kotlincrypto/hash/sha3/KeccakDigest {
@@ -93,10 +124,12 @@ public final class org/kotlincrypto/hash/sha3/SHAKE256$Companion : org/kotlincry
 
 public abstract class org/kotlincrypto/hash/sha3/SHAKEDigest : org/kotlincrypto/hash/sha3/KeccakDigest, org/kotlincrypto/core/XofAlgorithm {
 	protected static final field Companion Lorg/kotlincrypto/hash/sha3/SHAKEDigest$Companion;
+	protected final field xOfMode Z
 	public synthetic fun <init> (Lorg/kotlincrypto/core/internal/DigestState;Lorg/kotlincrypto/hash/sha3/SHAKEDigest;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> ([B[BZLjava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final synthetic fun blockSizeFromBitStrength$sha3 (I)I
 	protected final fun extract (Lorg/kotlincrypto/sponges/keccak/F1600;[BIIJ)[B
-	protected final fun resetDigest ()V
+	protected fun resetDigest ()V
 }
 
 protected final class org/kotlincrypto/hash/sha3/SHAKEDigest$Companion {
@@ -110,5 +143,41 @@ protected final class org/kotlincrypto/hash/sha3/SHAKEDigest$SHAKEXofFactory$SHA
 	public synthetic fun copy ()Ljava/lang/Object;
 	public fun copy ()Lorg/kotlincrypto/core/Xof;
 	public synthetic fun newReader (Lorg/kotlincrypto/core/XofAlgorithm;)Lorg/kotlincrypto/core/Xof$Reader;
+}
+
+public abstract class org/kotlincrypto/hash/sha3/TupleDigest : org/kotlincrypto/hash/sha3/SHAKEDigest {
+	public synthetic fun <init> (Lorg/kotlincrypto/core/internal/DigestState;Lorg/kotlincrypto/hash/sha3/TupleDigest;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> ([BZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected final fun digest (JI[B)[B
+	protected final fun updateDigest (B)V
+	protected final fun updateDigest ([BII)V
+}
+
+public final class org/kotlincrypto/hash/sha3/TupleHash128 : org/kotlincrypto/hash/sha3/TupleDigest {
+	public static final field Companion Lorg/kotlincrypto/hash/sha3/TupleHash128$Companion;
+	public fun <init> ([B)V
+	public synthetic fun <init> ([BZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun xOf ()Lorg/kotlincrypto/core/Xof;
+	public static final fun xOf ([B)Lorg/kotlincrypto/core/Xof;
+}
+
+public final class org/kotlincrypto/hash/sha3/TupleHash128$Companion : org/kotlincrypto/hash/sha3/SHAKEDigest$SHAKEXofFactory {
+	public final fun xOf ()Lorg/kotlincrypto/core/Xof;
+	public final fun xOf ([B)Lorg/kotlincrypto/core/Xof;
+	public static synthetic fun xOf$default (Lorg/kotlincrypto/hash/sha3/TupleHash128$Companion;[BILjava/lang/Object;)Lorg/kotlincrypto/core/Xof;
+}
+
+public final class org/kotlincrypto/hash/sha3/TupleHash256 : org/kotlincrypto/hash/sha3/TupleDigest {
+	public static final field Companion Lorg/kotlincrypto/hash/sha3/TupleHash256$Companion;
+	public fun <init> ([B)V
+	public synthetic fun <init> ([BZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun xOf ()Lorg/kotlincrypto/core/Xof;
+	public static final fun xOf ([B)Lorg/kotlincrypto/core/Xof;
+}
+
+public final class org/kotlincrypto/hash/sha3/TupleHash256$Companion : org/kotlincrypto/hash/sha3/SHAKEDigest$SHAKEXofFactory {
+	public final fun xOf ()Lorg/kotlincrypto/core/Xof;
+	public final fun xOf ([B)Lorg/kotlincrypto/core/Xof;
+	public static synthetic fun xOf$default (Lorg/kotlincrypto/hash/sha3/TupleHash256$Companion;[BILjava/lang/Object;)Lorg/kotlincrypto/core/Xof;
 }
 

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/CSHAKE128.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/CSHAKE128.kt
@@ -48,7 +48,7 @@ public class CSHAKE128: SHAKEDigest {
         N: ByteArray?,
         S: ByteArray?,
         xOfMode: Boolean,
-    ): super(N, S, xOfMode, "${CSHAKE}128", BLOCK_SIZE, DIGEST_LENGTH)
+    ): super(N, S, xOfMode, CSHAKE + BIT_STRENGTH_128, BLOCK_SIZE, DIGEST_LENGTH)
 
     private constructor(state: DigestState, digest: CSHAKE128): super(state, digest)
 
@@ -56,8 +56,15 @@ public class CSHAKE128: SHAKEDigest {
 
     public companion object: SHAKEXofFactory<CSHAKE128>() {
 
-        public const val BLOCK_SIZE: Int = 168
-        public const val DIGEST_LENGTH: Int = 32
+        /**
+         * The block size for this algorithm
+         * */
+        public const val BLOCK_SIZE: Int = BLOCK_SIZE_BIT_128
+
+        /**
+         * The default number of bytes output when [digest] is called
+         * */
+        public const val DIGEST_LENGTH: Int = DIGEST_LENGTH_BIT_128
 
         /**
          * Produces a new [Xof] (Extendable-Output Function) for [CSHAKE128]

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/CSHAKE256.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/CSHAKE256.kt
@@ -48,7 +48,7 @@ public class CSHAKE256: SHAKEDigest {
         N: ByteArray?,
         S: ByteArray?,
         xOfMode: Boolean,
-    ): super(N, S, xOfMode, "${CSHAKE}256", BLOCK_SIZE, DIGEST_LENGTH)
+    ): super(N, S, xOfMode, CSHAKE + BIT_STRENGTH_256, BLOCK_SIZE, DIGEST_LENGTH)
 
     private constructor(state: DigestState, digest: CSHAKE256): super(state, digest)
 
@@ -56,8 +56,15 @@ public class CSHAKE256: SHAKEDigest {
 
     public companion object: SHAKEXofFactory<CSHAKE256>() {
 
-        public const val BLOCK_SIZE: Int = 136
-        public const val DIGEST_LENGTH: Int = 64
+        /**
+         * The block size for this algorithm
+         * */
+        public const val BLOCK_SIZE: Int = BLOCK_SIZE_BIT_256
+
+        /**
+         * The default number of bytes output when [digest] is called
+         * */
+        public const val DIGEST_LENGTH: Int = DIGEST_LENGTH_BIT_256
 
         /**
          * Produces a new [Xof] (Extendable-Output Function) for [CSHAKE256]

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/KeccakDigest.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/KeccakDigest.kt
@@ -86,7 +86,7 @@ public sealed class KeccakDigest: Digest {
         KeccakP(A)
     }
 
-    protected final override fun digest(bitLength: Long, bufferOffset: Int, buffer: ByteArray): ByteArray {
+    protected override fun digest(bitLength: Long, bufferOffset: Int, buffer: ByteArray): ByteArray {
         buffer[bufferOffset] = dsByte
         buffer.fill(0, bufferOffset + 1)
         buffer[buffer.lastIndex] = buffer.last() xor 0x80.toByte()

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/ParallelDigest.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/ParallelDigest.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import org.kotlincrypto.core.InternalKotlinCryptoApi
+import org.kotlincrypto.core.Xof
+import org.kotlincrypto.core.internal.DigestState
+
+/**
+ * Core abstraction for:
+ *  - ParallelHash128
+ *  - ParallelHash256
+ *
+ * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf#6%20ParallelHash
+ *
+ * Also see support libraries utilized:
+ *  - https://github.com/KotlinCrypto/endians
+ *  - https://github.com/KotlinCrypto/sponges
+ * */
+public sealed class ParallelDigest: SHAKEDigest {
+
+    private val inner: SHAKEDigest
+    private val innerBuffer: ByteArray
+    private var innerBufOffs: Int
+    private var processCount: Long
+
+    protected constructor(
+        S: ByteArray?,
+        B: Int,
+        xOfMode: Boolean,
+        bitStrength: Int,
+        digestLength: Int,
+    ): super(
+        PARALLEL_HASH.encodeToByteArray(),
+        S,
+        xOfMode,
+        PARALLEL_HASH + bitStrength,
+        blockSizeFromBitStrength(bitStrength),
+        digestLength,
+    ) {
+        require(B > 0) { "B must be greater than 0" }
+
+        this.inner = when (bitStrength) {
+            BIT_STRENGTH_128 -> CSHAKE128(null, null)
+            BIT_STRENGTH_256 -> CSHAKE256(null, null)
+            else -> throw IllegalArgumentException("bitStrength must be $BIT_STRENGTH_128 or $BIT_STRENGTH_256")
+        }
+        this.innerBuffer = ByteArray(B)
+        this.innerBufOffs = 0
+        this.processCount = 0L
+
+        @OptIn(InternalKotlinCryptoApi::class)
+        val encB = Xof.Utils.leftEncode(innerBuffer.size.toLong())
+        super.updateDigest(encB, 0, encB.size)
+    }
+
+    protected constructor(state: DigestState, digest: ParallelDigest): super(state, digest) {
+        this.inner = digest.inner.copy() as SHAKEDigest
+        this.innerBuffer = digest.innerBuffer.copyOf()
+        this.innerBufOffs = digest.innerBufOffs
+        this.processCount = digest.processCount
+    }
+
+    protected final override fun digest(bitLength: Long, bufferOffset: Int, buffer: ByteArray): ByteArray {
+        val buffered = if (innerBufOffs != 0) {
+            // If there's any buffered bytes left,
+            // process them to append them to the
+            // buffer here as additional input.
+            inner.update(innerBuffer, 0, innerBufOffs)
+            processCount++
+            innerBufOffs = 0
+            inner.digest()
+        } else {
+            ByteArray(0)
+        }
+
+        @OptIn(InternalKotlinCryptoApi::class)
+        val final = buffered +
+                Xof.Utils.rightEncode(processCount) +
+                Xof.Utils.rightEncode(if (xOfMode) 0L else digestLength() * 8L)
+
+        val size = bufferOffset + final.size
+        val newBitLength = bitLength + (final.size * 8)
+
+        // final will be at MOST (64 + 9 + 9) = 82 bytes, which is
+        // less than outer digest's blockSize (136 or 168 depending
+        // on bitStrength). This means that no more than 1 compression
+        // would be needed to create some space in the buffer to fit
+        // everything. So, we good.
+        return if (size > buffer.lastIndex) {
+            val i = buffer.size - bufferOffset
+            final.copyInto(buffer, bufferOffset, 0, i)
+            compress(buffer, 0)
+            final.copyInto(buffer, 0, i, final.size)
+            super.digest(newBitLength, size - buffer.size, buffer)
+        } else {
+            final.copyInto(buffer, bufferOffset)
+            super.digest(newBitLength, size, buffer)
+        }
+    }
+
+    protected final override fun updateDigest(input: Byte) {
+        innerBuffer[innerBufOffs] = input
+
+        if (++innerBufOffs != innerBuffer.size) return
+        processBlock(innerBuffer, 0)
+        innerBufOffs = 0
+    }
+
+    protected final override fun updateDigest(input: ByteArray, offset: Int, len: Int) {
+        var i = offset
+        var remaining = len
+
+        // fill buffer if not already empty
+        while (innerBufOffs != 0 && remaining > 0) {
+            updateDigest(input[i++])
+            remaining--
+        }
+
+        // chunk
+        while (remaining >= innerBuffer.size) {
+            processBlock(input, i)
+            i += innerBuffer.size
+            remaining -= innerBuffer.size
+        }
+
+        // add remaining to buffer
+        while (remaining-- > 0) {
+            updateDigest(input[i++])
+        }
+    }
+
+    private fun processBlock(input: ByteArray, offset: Int) {
+        inner.update(input, offset, innerBuffer.size)
+        super.updateDigest(inner.digest(), 0, inner.digestLength())
+
+        processCount++
+    }
+
+    protected final override fun resetDigest() {
+        super.resetDigest()
+        this.innerBuffer.fill(0)
+        this.innerBufOffs = 0
+        this.processCount = 0L
+
+        // No need to reset inner as digest() is always called
+        // when processing blocks which leaves it in a perpetually
+        // reset state.
+//        this.inner.reset()
+
+        @OptIn(InternalKotlinCryptoApi::class)
+        val encB = Xof.Utils.leftEncode(innerBuffer.size.toLong())
+        super.updateDigest(encB, 0, encB.size)
+    }
+
+    private companion object {
+        private const val PARALLEL_HASH = "ParallelHash"
+    }
+}

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/ParallelHash128.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/ParallelHash128.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import org.kotlincrypto.core.Digest
+import org.kotlincrypto.core.Xof
+import org.kotlincrypto.core.internal.DigestState
+import kotlin.jvm.JvmStatic
+
+/**
+ * ParallelHash128 implementation
+ *
+ * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf#6%20ParallelHash
+ *
+ * @see [xOf]
+ * */
+public class ParallelHash128: ParallelDigest {
+
+    /**
+     * Creates a new [ParallelHash128] [Digest] instance with a fixed output
+     * [digestLength].
+     *
+     * @param [S] A user selected customization bit string to define a variant
+     *   of the function. When no customization is desired, [S] is set to an
+     *   empty or null value. (e.g. "My Customization".encodeToByteArray())
+     * @param [B] The block size for the inner hash function in bytes
+     * @throws [IllegalArgumentException] If [B] is less than 1
+     * */
+    @Throws(IllegalArgumentException::class)
+    public constructor(S: ByteArray?, B: Int): this(S, B, xOfMode = false)
+
+    private constructor(
+        S: ByteArray?,
+        B: Int,
+        xOfMode: Boolean,
+    ): super(S, B, xOfMode, BIT_STRENGTH_128, DIGEST_LENGTH_BIT_128)
+
+    private constructor(state: DigestState, digest: ParallelHash128): super(state, digest)
+
+    protected override fun copy(state: DigestState): Digest = ParallelHash128(state, this)
+
+    public companion object: SHAKEXofFactory<ParallelHash128>() {
+
+        /**
+         * Produces a new [Xof] (Extendable-Output Function) for [ParallelHash128]
+         *
+         * @param [S] A user selected customization bit string to define a variant
+         *   of the function. When no customization is desired, [S] is set to an
+         *   empty or null value. (e.g. "My Customization".encodeToByteArray())
+         * @param [B] The block size for the inner hash function in bytes
+         * @throws [IllegalArgumentException] If [B] is less than 1
+         * */
+        @JvmStatic
+        @Throws(IllegalArgumentException::class)
+        public fun xOf(S: ByteArray?, B: Int): Xof<ParallelHash128> = SHAKEXof(ParallelHash128(S, B, xOfMode = true))
+    }
+}

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/ParallelHash256.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/ParallelHash256.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import org.kotlincrypto.core.Digest
+import org.kotlincrypto.core.Xof
+import org.kotlincrypto.core.internal.DigestState
+import kotlin.jvm.JvmStatic
+
+/**
+ * ParallelHash256 implementation
+ *
+ * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf#6%20ParallelHash
+ *
+ * @see [xOf]
+ * */
+public class ParallelHash256: ParallelDigest {
+
+    /**
+     * Creates a new [ParallelHash256] [Digest] instance with a fixed output
+     * [digestLength].
+     *
+     * @param [S] A user selected customization bit string to define a variant
+     *   of the function. When no customization is desired, [S] is set to an
+     *   empty or null value. (e.g. "My Customization".encodeToByteArray())
+     * @param [B] The block size for the inner hash function in bytes
+     * @throws [IllegalArgumentException] If [B] is less than 1
+     * */
+    @Throws(IllegalArgumentException::class)
+    public constructor(S: ByteArray?, B: Int): this(S, B, xOfMode = false)
+
+    private constructor(
+        S: ByteArray?,
+        B: Int,
+        xOfMode: Boolean,
+    ): super(S, B, xOfMode, BIT_STRENGTH_256, DIGEST_LENGTH_BIT_256)
+
+    private constructor(state: DigestState, digest: ParallelHash256): super(state, digest)
+
+    protected override fun copy(state: DigestState): Digest = ParallelHash256(state, this)
+
+    public companion object: SHAKEXofFactory<ParallelHash256>() {
+
+        /**
+         * Produces a new [Xof] (Extendable-Output Function) for [ParallelHash256]
+         *
+         * @param [S] A user selected customization bit string to define a variant
+         *   of the function. When no customization is desired, [S] is set to an
+         *   empty or null value. (e.g. "My Customization".encodeToByteArray())
+         * @param [B] The block size for the inner hash function in bytes
+         * @throws [IllegalArgumentException] If [B] is less than 1
+         * */
+        @JvmStatic
+        @Throws(IllegalArgumentException::class)
+        public fun xOf(S: ByteArray?, B: Int): Xof<ParallelHash256> = SHAKEXof(ParallelHash256(S, B, xOfMode = true))
+    }
+}

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/SHAKE128.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/SHAKE128.kt
@@ -35,7 +35,9 @@ public class SHAKE128: SHAKEDigest {
      * */
     public constructor(): this(xOfMode = false)
 
-    private constructor(xOfMode: Boolean): super(null, null, xOfMode, "${SHAKE}128", 168, 32)
+    private constructor(
+        xOfMode: Boolean
+    ): super(null, null, xOfMode, SHAKE + BIT_STRENGTH_128, BLOCK_SIZE_BIT_128, DIGEST_LENGTH_BIT_128)
 
     private constructor(state: DigestState, digest: SHAKE128): super(state, digest)
 

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/SHAKE256.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/SHAKE256.kt
@@ -35,7 +35,9 @@ public class SHAKE256: SHAKEDigest {
      * */
     public constructor(): this(xOfMode = false)
 
-    private constructor(xOfMode: Boolean): super(null, null, xOfMode, "${SHAKE}256", 136, 64)
+    private constructor(
+        xOfMode: Boolean
+    ): super(null, null, xOfMode, SHAKE + BIT_STRENGTH_256, BLOCK_SIZE_BIT_256, DIGEST_LENGTH_BIT_256)
 
     private constructor(state: DigestState, digest: SHAKE256): super(state, digest)
 

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/TupleDigest.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/TupleDigest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import org.kotlincrypto.core.InternalKotlinCryptoApi
+import org.kotlincrypto.core.Xof
+import org.kotlincrypto.core.internal.DigestState
+
+/**
+ * Core abstraction for:
+ *  - TupleHash128
+ *  - TupleHash256
+ *
+ * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf#5%20TupleHash
+ *
+ * Also see support libraries utilized:
+ *  - https://github.com/KotlinCrypto/endians
+ *  - https://github.com/KotlinCrypto/sponges
+ * */
+public sealed class TupleDigest: SHAKEDigest {
+
+    protected constructor(
+        S: ByteArray?,
+        xOfMode: Boolean,
+        bitStrength: Int,
+        digestLength: Int,
+    ): super(
+        TUPLE_HASH.encodeToByteArray(),
+        S,
+        xOfMode,
+        TUPLE_HASH + bitStrength,
+        blockSizeFromBitStrength(bitStrength),
+        digestLength,
+    )
+
+    protected constructor(state: DigestState, digest: TupleDigest): super(state, digest)
+
+    protected final override fun digest(bitLength: Long, bufferOffset: Int, buffer: ByteArray): ByteArray {
+        @OptIn(InternalKotlinCryptoApi::class)
+        val encL = Xof.Utils.rightEncode(if (xOfMode) 0L else digestLength() * 8L)
+
+        val size = bufferOffset + encL.size
+        val newBitLength = bitLength + (encL.size * 8)
+
+        // encL will be at MOST 9 bytes, which is less than the
+        // blockSize. This means that no more than 1 compression
+        // would be needed to create som space in the buffer to
+        // fit everything. So, we good.
+        return if (size > buffer.lastIndex) {
+            val i = buffer.size - bufferOffset
+            encL.copyInto(buffer, bufferOffset, 0, i)
+            compress(buffer, 0)
+            encL.copyInto(buffer, 0, i, encL.size)
+            super.digest(newBitLength, size - buffer.size, buffer)
+        } else {
+            encL.copyInto(buffer, bufferOffset)
+            super.digest(newBitLength, size, buffer)
+        }
+    }
+
+    protected final override fun updateDigest(input: Byte) {
+        // Do encoding manually so unnecessary arrays aren't created
+        super.updateDigest(1)
+        super.updateDigest(8)
+        super.updateDigest(input)
+    }
+
+    protected final override fun updateDigest(input: ByteArray, offset: Int, len: Int) {
+        @OptIn(InternalKotlinCryptoApi::class)
+        val enc = Xof.Utils.leftEncode(len * 8L)
+        super.updateDigest(enc, 0, enc.size)
+        super.updateDigest(input, offset, len)
+    }
+
+    private companion object {
+        private const val TUPLE_HASH = "TupleHash"
+    }
+}

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/TupleHash128.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/TupleHash128.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import org.kotlincrypto.core.Digest
+import org.kotlincrypto.core.Xof
+import org.kotlincrypto.core.internal.DigestState
+import kotlin.jvm.JvmOverloads
+import kotlin.jvm.JvmStatic
+
+/**
+ * TupleHash128 implementation
+ *
+ * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf#5%20TupleHash
+ *
+ * @see [xOf]
+ * */
+public class TupleHash128: TupleDigest {
+
+    /**
+     * Creates a new [TupleHash128] [Digest] instance with a fixed output
+     * [digestLength].
+     *
+     * @param [S] A user selected customization bit string to define a variant
+     *   of the function. When no customization is desired, [S] is set to an
+     *   empty or null value. (e.g. "My Customization".encodeToByteArray())
+     * */
+    public constructor(S: ByteArray?): this(S, xOfMode = false)
+
+    private constructor(
+        S: ByteArray?,
+        xOfMode: Boolean,
+    ): super(S, xOfMode, BIT_STRENGTH_128, DIGEST_LENGTH_BIT_128)
+
+    private constructor(state: DigestState, digest: TupleHash128): super(state, digest)
+
+    protected override fun copy(state: DigestState): Digest = TupleHash128(state, this)
+
+    public companion object: SHAKEXofFactory<TupleHash128>() {
+
+        /**
+         * Produces a new [Xof] (Extendable-Output Function) for [TupleHash128]
+         *
+         * @param [S] A user selected customization bit string to define a variant
+         *   of the function. When no customization is desired, [S] is set to an
+         *   empty or null value. (e.g. "My Customization".encodeToByteArray())
+         * */
+        @JvmStatic
+        @JvmOverloads
+        public fun xOf(S: ByteArray? = null): Xof<TupleHash128> = SHAKEXof(TupleHash128(S, xOfMode = true))
+    }
+}

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/TupleHash256.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/TupleHash256.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import org.kotlincrypto.core.Digest
+import org.kotlincrypto.core.Xof
+import org.kotlincrypto.core.internal.DigestState
+import kotlin.jvm.JvmOverloads
+import kotlin.jvm.JvmStatic
+
+/**
+ * TupleHash256 implementation
+ *
+ * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf#5%20TupleHash
+ *
+ * @see [xOf]
+ * */
+public class TupleHash256: TupleDigest {
+
+    /**
+     * Creates a new [TupleHash256] [Digest] instance with a fixed output
+     * [digestLength].
+     *
+     * @param [S] A user selected customization bit string to define a variant
+     *   of the function. When no customization is desired, [S] is set to an
+     *   empty or null value. (e.g. "My Customization".encodeToByteArray())
+     * */
+    public constructor(S: ByteArray?): this(S, xOfMode = false)
+
+    private constructor(
+        S: ByteArray?,
+        xOfMode: Boolean,
+    ): super(S, xOfMode, BIT_STRENGTH_256, DIGEST_LENGTH_BIT_256)
+
+    private constructor(state: DigestState, digest: TupleHash256): super(state, digest)
+
+    protected override fun copy(state: DigestState): Digest = TupleHash256(state, this)
+
+    public companion object: SHAKEXofFactory<TupleHash256>() {
+
+        /**
+         * Produces a new [Xof] (Extendable-Output Function) for [TupleHash256]
+         *
+         * @param [S] A user selected customization bit string to define a variant
+         *   of the function. When no customization is desired, [S] is set to an
+         *   empty or null value. (e.g. "My Customization".encodeToByteArray())
+         * */
+        @JvmStatic
+        @JvmOverloads
+        public fun xOf(S: ByteArray? = null): Xof<TupleHash256> = SHAKEXof(TupleHash256(S, xOfMode = true))
+    }
+}

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/ParallelHash128UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/ParallelHash128UnitTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import kotlin.test.Test
+import org.kotlincrypto.core.Digest
+import org.kotlincrypto.hash.DigestUnitTest
+
+open class ParallelHash128UnitTest: DigestUnitTest() {
+    protected val B = 100
+    override val digest: Digest = ParallelHash128(null, B)
+    final override val expectedResetHash: String = "4860c15ced13a8e56e95a6c7ea14e55be8ad8db61373f1b2372687dfd3c9c38f"
+    final override val expectedMultiBlockHash: String = "a70e14d1ec490bb8547b89fdaa590203ac80505e21c4836ab9c8a31baa32edf1"
+    final override val expectedUpdateSmallHash: String = "f931e465e69bb9895cf655eb5227a55f8775eb0ca3b04edc7c9edfb577552f56"
+    final override val expectedUpdateMediumHash: String = "57d11d6d370bd6ca17ad773f590e82d06cb2f4feb36dda629263ce723ac5d97e"
+
+    @Test
+    final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenUpdatedSmall_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenUpdatedSmall_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenUpdatedMedium_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenUpdatedMedium_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    override fun givenDigest_whenCopied_thenIsDifferentInstance() {
+        super.givenDigest_whenCopied_thenIsDifferentInstance()
+    }
+
+    @Test
+    final override fun givenDigest_whenDigested_thenLengthMatchesOutput() {
+        super.givenDigest_whenDigested_thenLengthMatchesOutput()
+    }
+
+}

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/ParallelHash128XofUnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/ParallelHash128XofUnitTest.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import org.kotlincrypto.core.Updatable
+import org.kotlincrypto.core.Xof
+import org.kotlincrypto.hash.XofUnitTest
+import kotlin.test.Test
+
+open class ParallelHash128XofUnitTest: XofUnitTest() {
+    protected val B = 100
+    override val xof: Updatable = ParallelHash128.xOf(null, B)
+
+    override fun read(vararg args: ByteArray) {
+        (xof as Xof<*>).use { args.forEach { read(it) } }
+    }
+
+    override fun partialRead(out: ByteArray, offset: Int, len: Int) {
+        (xof as Xof<*>).use { read(out, offset, len) }
+    }
+
+    override fun reset() {
+        (xof as Xof<*>).reset()
+    }
+
+    @Test
+    final override fun givenXof_whenReset_thenReadReturnsExected() {
+        super.givenXof_whenReset_thenReadReturnsExected()
+    }
+
+    @Test
+    final override fun givenXof_whenPartialRead_thenReadReturnsExpected() {
+        super.givenXof_whenPartialRead_thenReadReturnsExpected()
+    }
+
+    @Test
+    final override fun givenXof_whenUpdatedSmall_thenReadReturnsExpected() {
+        super.givenXof_whenUpdatedSmall_thenReadReturnsExpected()
+    }
+
+    @Test
+    final override fun givenXof_whenUpdateMedium_thenReadReturnsExpected() {
+        super.givenXof_whenUpdateMedium_thenReadReturnsExpected()
+    }
+
+    final override val expectedResetHash: String = """
+        c7621831cc04198b9149c0572497ba39a3d7609408a728d9778a3363dded63b9
+        86adb4b4e9bed4e20ef02b79829e6643564a5af54144e70e2bdf93a6310c49e6
+        6a7ccd77c6d1f4b44bc3258ed9f405abe36b92aaf3a4d4b30ae9d4807057ee10
+        ff25e4f351b65e8bb7b05de4084a7c008e58d0592662041f865e94e805ff3a22
+        7f3c8f1457561da0f6cdada798dedcacdbabc592e79307bea11c4ac29a0376ba
+        eb8b292c6263f98092a1dbc9bd78437a8c204c8a20f3638b5ea527c7271cd010
+        edebf09f34a8826c8be53800bec8d8afac36f019046bb88c0a7f5737e5781a81
+        8d78b79fd4175b6884bd9952d7c8ed9b78e5998363a899fb5a479a9277010284
+        52e4f0042d165cfc7a8175fcb8fb7411aa0777b1b76fb5791591a4cebc25b485
+        07eb87b22875ed74cc0052e1b499b4b208ebd321247c583dfb7cfa5ebf172298
+        efc7673c5117a9fd1969b230d16f8e6910a5497710810818289e8783a3987f07
+        3d4d7202b7e023ae8550f2e2e795ecd13ca942fba459b67579b902eea07e984c
+        91fda399230cfa07eea125e18c9a338e2803745bfe909893211aff51d05bb048
+        926cef8f242fc93257e3fd71593e8d6fb3c5829e870461ad6be97a2e67e6c1d8
+        d974676d7ffe67a8893556830bd2f42ea2b16ab18cb430c14ecffd2579f6f2c1
+        9663ae6c70d644ebb044d25a1dfe59812922bef659fab77541d27a6817b02487
+        a2c96e2f8504f6f879761d91867e82db00308eb1b5df2479542aab1cc665c9e4
+        ce0355e31127df13fc18c703cb5e6ef09ef12fe4f6e84b12645d6437fd5d588e
+        1e584ee331317d8d4256bea3fa546eed0547cdab8ddaad2a07992c8857b436e0
+        ebc2991b17b8e8b2760eb9d0a34919e484cb9c24730c1f31625804a278562b34
+        85327057f51457dd8bdab35f68956e5a67f244795ee23087e9e285e3a2f10d35
+        c9b8ddf47351cba9a975567875d2ec7f7fbe0b7b8651c29f8f4a8e953252d9c5
+        85011f7253c41bfcedb9c3e9d51b02c36f0d7236cc1cb7e3d039a63cc552095c
+        178b585ee46159fbf32875fb50c49767ab6aaa7a32b544aeea0ccd736f42b979
+        441324cf1d9a4b19ea52636d9dd78cf3d2169f21ad697e405bc4a77f0f2c7caa
+        86d10849315f54085ca9d390986c0b48db8db8d525d1e9579f9e221699f01148
+        17a1ce2ae089932d8eb77b59b7feaadf5d0958d4b6439bb23156764d98a30bf1
+        1c51cc8a94768c3ef7dd82815d88a16c51401a5fa6a7f086a8bbaa7458aa3bd8
+        e6e98721a25a4ffb385a232d0e018cc0cdf3b72a02a85a545f38bff9a0e5a66a
+        ddc8b02abaedc18a2a256ee133858034f3c3ab6fa021fb9a74b33ea1f96cc431
+        37142b87749be4f46b0d53eb65bd83e55611ee0bd6ae1813768e99bdfbd85636
+        abdf88f107c9d01f3bae7db55e93704e86feb5d4babe2f238a4c2b7274020971
+        5cf4d6bbdc941c28258a60b98b04dab4bb6451a370db343932ccb6674a7253f5
+        5d41213a1acc7749a37d44c34b46baab1f8c6c2dd5cdbbd7b4584f00b764091d
+        a722adc46da9941076d6bb193478d3aad2be8a88250d1a1f3c1801105f4b3039
+        a7dfd638e4182603c6e358e95ef5f89d133948784ca7fe9d5a449e5c05d1311a
+        f5ed7188b5eb0b5f0f0eacc72864fb53b6e1875c757c9a61bb73e99c3b82bfa9
+        ab7e3399bc73a822161e93be3ff2f74e551da2c3c1ce5e8377c6e159560b6f7c
+        f237456177625d52dd
+    """.trimIndent()
+    final override val expectedPartialReadHash: String = """
+        00000000000000000000bc9d4039091361b02ee01389287b71529d6eb12e84ac
+        ef6cef1b295670ed011d7f7dd5aeb73aee5624d75a748a1f185afe6beec95042
+        cfe334ab1a1ac7e8439c013ade457d0f518ecc5879297dfb1504c2d223dec5b3
+        fec5430c468cc931bc260878bddf46a4961e2dd1c10c3d06dc3f37bfd5f13cc3
+        e524db5947ea0865bf3cac48f960045f65a78577b3079589f46cdb26dcc6f287
+        ce81ff5c33cef342dd3bdeeedd9b099f4f15efe792924d894a585990e8470000
+        0000000000000000
+    """.trimIndent()
+    final override val expectedUpdateSmallHash: String = """
+        bc9d4039091361b02ee01389287b71529d6eb12e84acef6cef1b295670ed011d
+        7f7dd5aeb73aee5624d75a748a1f185afe6beec95042cfe334ab1a1ac7e8439c
+        013ade457d0f518ecc5879297dfb1504c2d223dec5b3fec5430c468cc931bc26
+        0878bddf46a4961e2dd1c10c3d06dc3f37bfd5f13cc3e524db5947ea0865bf3c
+        ac48f960045f65a78577b3079589f46cdb26dcc6f287ce81ff5c33cef342dd3b
+        deeedd9b099f4f15efe792924d894a585990e8476b881cd442c2a9038d0303d3
+        14dcca4fe31abc9e5f687a38cd3a781887c1341d30366da4d4780661aff56ae0
+        e52cb112ea68f7f88eb5637860fae3b03cd8dd8cfca6988392847c6ddf3cb7b3
+        32c94500d56137f32a6cc193d6ff04a7a04fb4de841dfa433c44607373b9a194
+        45c5d63d447e481b0260ecf6f39c4d58135e4f92129d57351db6568184cb234a
+        aa5c5985f74ff886675f1354065e291ac8d3f2091ce799bf33a512611affda3f
+        a9cb5d4780651d983e9bbe379ae3a35be687a340dc345ac816ac36f73b9101d9
+        40075e472d276ad6b21817b2ad1f0c64e0faae1a84e3aedb6c60e99f5143b0a8
+        c2256bde864014c588b56348efaca8f95662bcb86ef50bda09b194e6e22aebb7
+        4a51cb66eadee15403181f1f37b77c65ce92da543ea4a90faf45db492c7bdc8a
+        660aed28acb84e8701aa4a385e90a51b7ea27a614dc8a3ae6c61274f65e512fb
+        df14f40330bd4e8d3793b4103381dada24c4adefd6e47489d0892d25aa32e7d4
+        2f7d11c7d882ab3a193d659785bb2f807282ea21beedd8fa7b1a1f856a6c71b0
+        08ed7535
+    """.trimIndent()
+    final override val expectedUpdateMediumHash: String = """
+        299c28038c48937115fbec79483cb4e0f791f078de56d7dee68eeb1d694114f2
+        7bdf79661db12d849af938f79143484a95f8606926e33eb6c3c1e9e9b5edb618
+        216f511506be20ca7fe21bcf3a2047499c5032f0fbc4a32abc3378e3d8fd5b2c
+        3b263eb4e2ddf175e5e584196931fb284218e3aefe33eaa08fbd3809b15b705a
+        f2a852f9919eea8f66eff1f80f7ed18744de5293c5c928663b45dad604eceeda
+        336d88943cf95644cebab42e8678259d0f6bfe0105a57f548f72f518ba404059
+        b50be9f65163617154682617e8418ff71e31d489f9fcac18fd94780857bf2d0a
+        63a074c4bd0ea4d4318ef66c58c7076c45f010991f2fd22372f0c4978fca9e0e
+        c07018aae799f112e35c1306cf92067cc101ce4adfa24920b768e215820a6423
+        456848034bffc7d36247aec634ccde563d2e7a526cd6acfda4148c21b206440e
+        6f8f72b6f28917997a56fbb0b3d27cb653a984a59af3f1c5611477a1f010fbbd
+        2a34e36466ba959aa64f8c54156bec6fb2350a86c71e554fae4fe9742cbbd468
+        97fa2cbf601b256b5963aa33d60d0303735185222e00d5ec620363fad1cf6a8d
+        97bd086d5e2336bf5ec298134cbca8516197cc5db1ae42b51f9380f227141374
+        85bad4496de3cd83c385d47ac60605fccdaf90f77850f3cf1d83a48cd4129d3a
+        23f85650603eae5dbc355fe576a25643448c33515d7bc6bd10c9b6f9211f010b
+        de64b915bd6f954963e219a157e442f394b272043cdedb661409adbbe35f4250
+        9d6ab54580635950678fc816beae6ace051c876afb105415b28f5b4302e542a9
+        8890835e4fd545c1b388a4cfb41a3e5fb39dc41cd6647ab795814b8b3c05fe4c
+        d7fccfe2a9d2009fd3420cbacd70e72a8b568f41e88811353e68cc2756c27e56
+        7d0288ab9999e7762f295c8cb86b8ada58e3ca732aa5e9315b0597aa3de38f01
+        a53a97a16614862a76ae68cd1c969fa1f8e3dd8a6fcad7a5813d842b6c4c307e
+        981b59c0c62a7161060cf4ccd8dd2abd3ae01d407e54d0bc7600a07391cab11e
+        677afd46a6875301f1ab6a990963b216d27b1a375a9b06789549e8141ef7034f
+        f5467e3e6d235bcaff398c7beca64ba7c598c480e3ac66d6b1cfde1436030497
+        f82fa21c3c9b2cd1dedac77fbdaa041bd279582d4914f52e70a7c01c7ee21824
+        239945f954b0dd0e6940c9da5d5413c3a901f91645b6ca9b386e30c723fa1101
+        de00c2ef2a1237fc55cfdf80189354a8ede7d741256334ab5af18febe27bc5a5
+        bb9ca491ed04159f9b3a5a76d33c314ca2c1b2e6258e1397
+    """.trimIndent()
+
+}

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/ParallelHash256UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/ParallelHash256UnitTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import kotlin.test.Test
+import org.kotlincrypto.core.Digest
+import org.kotlincrypto.hash.DigestUnitTest
+
+open class ParallelHash256UnitTest: DigestUnitTest() {
+    protected val B = 40
+    override val digest: Digest = ParallelHash256(null, B)
+    final override val expectedResetHash: String = "c912d0bdb32207cdde2741dd89b024d347bf6c4b21b0dfb993ac7c655338efb8600758399450135a617e0196b2aa2aa530f89f45f5a08b6e30bb14336aebf6ac"
+    final override val expectedMultiBlockHash: String = "db01f29fb2ec302a81d008adf280c61f7f53464a6d1f6bb358c91cf0f65270a31bfe8d290a9cba0112337049e9dc3cb0df46572bc94e171ccd31b3687741f634"
+    final override val expectedUpdateSmallHash: String = "0b5b7211348311af030dc87fa746a6715156d4cd8c8ba6080d787a2434b865eb0427c39ffa91dcc7d1a28033a56f2fc766a218eb435dd15de44a25a448e2d5ac"
+    final override val expectedUpdateMediumHash: String = "1d3bde77bf3ab54e5501d2160854a707088aa0060429c273c7b428dc5dad007a65868d0bdf6cec557d5efb8c6c9d48923621aa034edb7e32cbdd878e82897acf"
+
+    @Test
+    final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenUpdatedSmall_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenUpdatedSmall_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenUpdatedMedium_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenUpdatedMedium_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    override fun givenDigest_whenCopied_thenIsDifferentInstance() {
+        super.givenDigest_whenCopied_thenIsDifferentInstance()
+    }
+
+    @Test
+    final override fun givenDigest_whenDigested_thenLengthMatchesOutput() {
+        super.givenDigest_whenDigested_thenLengthMatchesOutput()
+    }
+
+}

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/ParallelHash256XofUnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/ParallelHash256XofUnitTest.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import org.kotlincrypto.core.Updatable
+import org.kotlincrypto.core.Xof
+import org.kotlincrypto.hash.XofUnitTest
+import kotlin.test.Test
+
+open class ParallelHash256XofUnitTest: XofUnitTest() {
+    protected val B = 237
+    override val xof: Updatable = ParallelHash256.xOf(null, B)
+
+    override fun read(vararg args: ByteArray) {
+        (xof as Xof<*>).use { args.forEach { read(it) } }
+    }
+
+    override fun partialRead(out: ByteArray, offset: Int, len: Int) {
+        (xof as Xof<*>).use { read(out, offset, len) }
+    }
+
+    override fun reset() {
+        (xof as Xof<*>).reset()
+    }
+
+    @Test
+    final override fun givenXof_whenReset_thenReadReturnsExected() {
+        super.givenXof_whenReset_thenReadReturnsExected()
+    }
+
+    @Test
+    final override fun givenXof_whenPartialRead_thenReadReturnsExpected() {
+        super.givenXof_whenPartialRead_thenReadReturnsExpected()
+    }
+
+    @Test
+    final override fun givenXof_whenUpdatedSmall_thenReadReturnsExpected() {
+        super.givenXof_whenUpdatedSmall_thenReadReturnsExpected()
+    }
+
+    @Test
+    final override fun givenXof_whenUpdateMedium_thenReadReturnsExpected() {
+        super.givenXof_whenUpdateMedium_thenReadReturnsExpected()
+    }
+
+    final override val expectedResetHash: String = """
+        fa8be91f26c00d91c3c2f930ec4ec89488e32df18a1f0edb4fabaa68a8264793
+        589116e7374dce9f4d405251e4fcf20a6c9adfb83456da5fbe85964078b3d259
+        b1f68ac8392c3789b6e3d5c4382379317caa0f1c6057ff5e12abfa50d50b4b57
+        9f99fba1466526486d7c5b3c5348d9ba068672d9eb92e12fee2d0b4a7540acf0
+        975d1e069aea1afb36bdf9dc161560dc2a896e116cd520c4d52289fe2e73924b
+        38fcf216429d710cfb4255e30aa41a2ee44941483c0fa4bbc889040a90fd5d26
+        0d46cceac27cff8edcd0da25ccacfd37cff739dc24de706af6cbba60212274ba
+        4d937d8e51c205cff8047fd88729a0d0780d9d46dd39175e01ee72ab3a6718cb
+        e8644cb0f4266058eeb6a1bc3d1133a48801ea73be7c74ade5cef912996ebaff
+        3c7e94613b3c082161a6cac73c6cac619fcf5e2fc24b03d626d723eda04d7491
+        bab8d7afcc331be1817cbda5c040b0b6a1415de617228c024d00bb37c47d1a90
+        b4d108b358123abdda3c0e95b9e8a8bbd3688e881d441976c32d13e2e7729722
+        e8fad24e53f19b4f8089bbfa2a0f54524510f4d41f949cff560bc14615537dbe
+        cef2c3e681eb109ef68b345b77e1ace1fe23c150ee1876a9442ac3bf6e88659b
+        b166e99b15ce0406624a8dfa43170725fa6000ec1bf052ad3dbfdb6561433fda
+        cf2319486af8b3cb53184f889ed9cb458c09de44adbe5e40925f3e4e9fbb6635
+        3592506af02fb5921d64d83bdcf12cd36fef63dab8fccf57015237649d8f0aeb
+        10a12cc578ee20694e5871bd92549e27777048da1ce9219592ec8e45c1e201f3
+        205f206cbcd7a8808f43fcdd0d3ad45a1dfadd96b22589b475d101c51b685e61
+        669a783bda2232883bf3b44990df4545556a08b4c5ff0055e71c0f748e0fe0bf
+        c84e10a50f1875eb057a4fddfade0c86380d9fdacd656191c7e00604f9e7202d
+        78cbfbe08d8813ec3d9931290deaeb8aeb0f9c733d4b599430cb162d181f3300
+        c50c37f6aeb3d310df336bb1a29b8e072cabb28a4c843bb8e2e4ae27cf0dd8bc
+        792c0f8a4f7e16a5ee549f1d89c0ab7998e9b54c1da4b65e082c1b25763f07f8
+        dcb91dee894a32f7a6a0fd9f6f942bc1afbb78ae6e8330c223d8ee6d4dad40a1
+        b93ea248e0b54f058e01cea42702d9bb3b9f57cfcaeccabafa5e985230eb9b58
+        29e666d8705766f5dd8500b2e3ffeee2e607e4b61d89a9e5d91fce303a05a3c8
+        b7a717e601f08f6bf9d8ef1b699f29f96e13d9b7f612ebab46bb37f2b873da8a
+        9b4e829b621ca3bb876109962aa51757e6dd014e500537e5aff3a4affe03597b
+        639361c29515cd573af9871cd1da4d60990a4110686118881c21b6aa52518971
+        a0c90796e9b6cd0c8a9d87c20ebfb83c14a3b72573ae8b0d30e6080baca7a5cd
+        7bfc35350dc4276b8e3faa10e46329273a54cfa99c5d746d0fbc4790346c5091
+        ed46bddb084fcf2ddf1b491da0f2424d5c598718894b8737b83651c5ee3dda8e
+        02dfec471ac691d49d5280101b0175f969b0301eb003c86951b5163b332476fd
+        7675304282dd22c8a010ecfda037bbc2e5b1aac0649bd4ea5cbe23ae1cba1e55
+        6502975cf8b52300d6798d987d11af690d20a34f0c38c44eca78f061dd3bfada
+        fea1bd5bb1c176e108beab582daae571ec26fb891b022b29a74b222aab50641b
+        43bcd6ca49d6f8f27f45bf2cf7ce30410c6753bc18737b95029f40973221a171
+        84270b25b3a5affb25
+    """.trimIndent()
+    final override val expectedPartialReadHash: String = """
+        00000000000000000000d8fba9a826cbb771d747cee9e02c43cd8e5409fe7ba6
+        873ddde069d3426dc0b28658617f20b4484e4b1b5621f376639d99c781dd49ad
+        a212e1f766bdf431f4d40408e19074f78cd82373e3678af00f5c84ac754f8d2a
+        fdb97aa994a7955067cddb5dcaee88e5806012ac425a42d971d7fab6e0bfa7cf
+        a5c6ee585f49420adb5b05b927f56b667d74e96570014e910f9e3b9c3d6bed8d
+        52b03694d24306161acbcb35a7451685def96d19c039534d5cc3d58b93cd0000
+        0000000000000000
+    """.trimIndent()
+    final override val expectedUpdateSmallHash: String = """
+        d8fba9a826cbb771d747cee9e02c43cd8e5409fe7ba6873ddde069d3426dc0b2
+        8658617f20b4484e4b1b5621f376639d99c781dd49ada212e1f766bdf431f4d4
+        0408e19074f78cd82373e3678af00f5c84ac754f8d2afdb97aa994a7955067cd
+        db5dcaee88e5806012ac425a42d971d7fab6e0bfa7cfa5c6ee585f49420adb5b
+        05b927f56b667d74e96570014e910f9e3b9c3d6bed8d52b03694d24306161acb
+        cb35a7451685def96d19c039534d5cc3d58b93cd073f77566cd0152563169768
+        5a67be518f25222e46336a37fcce9317b6ff915392a929cb5dcc15eec230458a
+        c375826206b58b059b0173b5c4b9c1ad2ec3252ef0b7c15ec95a6c50a8e4a474
+        c37aaffc778366e9bd5bf42002e0ddbc04c26beadca5e4430e64f2e8059f0f05
+        b1eb1e0e1250ebdd2f8bea3df0367c7993215c65023e7bd6186da68f153a71b5
+        8356747af9b083ed196fe270bc50e40927d00acea6f22d9f139160bb305b1bdf
+        74e2217f8740628e503da01ac732a437d7e27f8317171b15da8cad71a884ac59
+        a56ba9d2f48976b3eed702438346a7653b15ff5a796d799527869d540b3b13f9
+        47a14d8c770b77ceb0bb3c26df008ce5cb8ca7767d1519a37c1ecdadae61e80b
+        e7c98de729aa5d91f6e8d8b4de2104a69bf92803d0b11ae5e9ab37cf433656bc
+        7ec0485b1114b89dd7c41290f64379551b99fb00c9b7e682bb712581db283758
+        3351a538c29e7aed360e895894fed02f50ac239c7c6c49b332fcb631dc08bff8
+        8f67e1d7dd16133fb66dc99c68af2ab112fdae9421d049b4c02b607f29d26275
+        da56684d
+    """.trimIndent()
+    final override val expectedUpdateMediumHash: String = """
+        b1f562b857bc609d32776768696b4fdeb9b05eaa31d23695485116a4fbf07700
+        19cfac575b4a703883dcfbe13488fd4b513fb196265386d6dd359e3e56b58ec0
+        a0de720d07badb809927e68d4542731ec4c1ce6de652c95b875cfd995299b66e
+        6e30f2c86c73cddf1d930f5e0c79bd27200f19777e430af2ae9ca3b498346464
+        6c3c9f77da5acee85aa422836d110a63345a646f9b5c40f1b82fbb1a32ba6e16
+        9f24c2402af4fecab9dfe0577decabe1f4ecf1572ff23e6380ea55030cb29e57
+        6bcb9b03d603b73a6ba87d9380b81c162c1f679c6c223612bc7a0d2a2ad22b78
+        e5f4fb5550ac0b5e419ae1b833879cfe99e32c13192d983f83812eb960a97e83
+        e1ab2c54540688e2f80c659eff1561b70106201f0ba278d5e229a44a276ca83f
+        6c3add3f82c187a36ff726be2a61534c7eccff51c0eeab581ea82cf89113a1fa
+        f1bb74673a3be40c97c857511265c95c46d2cdb78db1eae16607470daaa8eadc
+        1a2bf396bb9de9aec5b6b95f5800f327dfa23b7ec1b85127471a3b8607c7a880
+        ffb6703c6309edc1d0583f302a82e839c703d5212c8db337283e00cb45b037bc
+        ae343955c28129d3157f42f0327dea8e28bba03f59de3f58dc359f22e58bae08
+        627bb4f9391ad2a0b9eac9a0f0e419a446aab50d740cb8d145a56161d5624054
+        22f1a527dc478e3b1178b196fb85ad87017f7d455ecbe62c258204fa10dd5590
+        9460469f052b0152f422fb8efae5cbf5ef1ec8f162c30dc7f77f188fe6da123f
+        c140b0233f49480284cdcdb8897c3918218a5f599363c5c1a4c145f23d164b1d
+        3118f40d7e002f1b6ae68a08e0c8bdcbedca6c3628ead153b32b7ec497e291ef
+        309e9e1e98c367a7b646c1f1e5511d65bb1f30796bec64f4e3a2e07ec93f8a04
+        2321d6cc5bd76ed028e653545921c93a68e474f0ce514385066b4e9efa62385c
+        c4b33551e305138a2dab705663e3c2639b2c25c417c5ec822bded88ae09a79e9
+        37e880650ed309dfc5b718e8140107afaac2c45d34d6969c29c8c5b3ae4c4b23
+        f015a02eae3a495c5400bf5ce1b8b9a80df66edd71f8cb28beb1b93ce658e024
+        e38cb95ef7d94be7f81156ebbc54b26e2c16fdf5af0adee2ae8e54a152f72659
+        11d996f39b78d00f9561f9eea35c7c82bbf2511012b90280921d460de65536d2
+        d56a86667ede1242380a461011cc63438131708ef2c09a7bde2139b3274712b5
+        345a7000e044989fb2a2856e50d316e3a618b751138a14283ef8e771c6db5387
+        6204dc099f8237fbb09b20860e6b7f1f462425e23f617df1
+    """.trimIndent()
+
+}

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/TupleHash128UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/TupleHash128UnitTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import kotlin.test.Test
+import org.kotlincrypto.core.Digest
+import org.kotlincrypto.hash.DigestUnitTest
+
+open class TupleHash128UnitTest: DigestUnitTest() {
+    override val digest: Digest = TupleHash128(null)
+    final override val expectedResetHash: String = "786aa3d4fcaadf0aa723a4818a1a72de2330d613e5de7ae4eb6cb4cdd26adba2"
+    final override val expectedMultiBlockHash: String = "7b216e38222080216227e5ff6a402e88f3782e7fe3eadb03de03296ec9f3c060"
+    final override val expectedUpdateSmallHash: String = "a3e4e5f23ff4cb7587a83fe386f37cf3e9f80b0ba5d74de9e72815079b13d660"
+    final override val expectedUpdateMediumHash: String = "98be957009fca08674e795afd8660a3d46a1a9899f1539ef0b9d5e1acc73c0bf"
+
+    @Test
+    final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenUpdatedSmall_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenUpdatedSmall_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenUpdatedMedium_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenUpdatedMedium_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenCopied_thenIsDifferentInstance() {
+        super.givenDigest_whenCopied_thenIsDifferentInstance()
+    }
+
+    @Test
+    final override fun givenDigest_whenDigested_thenLengthMatchesOutput() {
+        super.givenDigest_whenDigested_thenLengthMatchesOutput()
+    }
+
+}

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/TupleHash128XofUnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/TupleHash128XofUnitTest.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import org.kotlincrypto.core.Updatable
+import org.kotlincrypto.core.Xof
+import org.kotlincrypto.hash.XofUnitTest
+import kotlin.test.Test
+
+open class TupleHash128XofUnitTest: XofUnitTest() {
+    override val xof: Updatable = TupleHash128.xOf()
+
+    override fun read(vararg args: ByteArray) {
+        (xof as Xof<*>).use { args.forEach { read(it) } }
+    }
+
+    override fun partialRead(out: ByteArray, offset: Int, len: Int) {
+        (xof as Xof<*>).use { read(out, offset, len) }
+    }
+
+    override fun reset() {
+        (xof as Xof<*>).reset()
+    }
+
+    @Test
+    final override fun givenXof_whenReset_thenReadReturnsExected() {
+        super.givenXof_whenReset_thenReadReturnsExected()
+    }
+
+    @Test
+    final override fun givenXof_whenPartialRead_thenReadReturnsExpected() {
+        super.givenXof_whenPartialRead_thenReadReturnsExpected()
+    }
+
+    @Test
+    final override fun givenXof_whenUpdatedSmall_thenReadReturnsExpected() {
+        super.givenXof_whenUpdatedSmall_thenReadReturnsExpected()
+    }
+
+    @Test
+    final override fun givenXof_whenUpdateMedium_thenReadReturnsExpected() {
+        super.givenXof_whenUpdateMedium_thenReadReturnsExpected()
+    }
+
+    final override val expectedResetHash: String = """
+        d15d5f9a99da1149260426b0d43571d6244d19dc1296567ed34c90aca32a57ef
+        36bcd780b974db5783a53d9ee5dc67f29bc5f5c59b6e0502a7a5d1079cb2aa8c
+        d82d24521eb71d2d914effbbc5d38cff4c72e090f6fd09727016d8b3ff3a9b7e
+        2cf9ad38cef2bf41f0f0f79834fb1739b6563bf93aa58691b1ff946d15e58790
+        9ff8f5fcb6a60e9f9d204c0f3c37b4e85b6fdbf0da66e763caedfaffe62fe2cd
+        591a7361c364d0b344858f3e9cbfc1f4ba3a503d4603933832582cdf6734589b
+        68633dfdf85e787e5aff9ab2541c83b88a6f66cf07ed8ef5cad7158fe12722c8
+        4f15c5242350f79cd4ab247a82efa4e0de128b14bea7d690ad84142cd720c27a
+        3b00cb9ef22f8bbc54e67c4c18fd0b28d84cfb070e073ae2f2336ddb5dbb6aa3
+        3964fc5552d3bce354d502e5c887adeff7397ca4d48b1d8a923beccc10ea087b
+        a64818975279f92f61aa5c45e339d74dcb4e41d2c2bfc72520709a59f7fc5d18
+        3b3e96c7852d2b6a635a611f8d0fec9741706a3743a609324342c8ed5c9aff42
+        467d9107df5de94e333b0f2d1adc91d2caa2488cf9599df17ad898cc3d0cb24b
+        6522800642cb400c478487a5e4c7e4f015d13f973fc662aafcd10f45c53165a7
+        81fbe23f9e0760a6631d8c75d6d6a60d83d7372914a369caf9a70d9619c504b4
+        cd38d3b7fd3bbc3ecce69e655516da3cf2b4172078428f0835d041de9afcf559
+        9a81b44167473837ce9aecbbf10ae08959d976abad1bdb5ae8188276b99c739e
+        15f467a324aa46211890f8305392eb176e5f6f86642d6445563494664f5b0522
+        29efa26f5d1ae4d0ecd79de42fa7b11ad6c81197370831c5175aa0cad2d73342
+        16a62cc5da1ac7115efd2a55a0e7f2ed4ed70298ea77a9a923bb446cdcd17bfa
+        859bc8e79d05e04a77e0a68e0510597be69ff31419f14388b0b2819b0e1d5f1d
+        cf91f20dc6bda3e1993dd6e08957afb2d8c256db8f61a420d837b9cab4c43f72
+        ae5a9c3da3d32e63138d0fb637f6db97ee457ca517ff7ab4212edf3fe8b80eeb
+        3e3f4ae86f1b5f4957e87101e35781dab82e8a2c4390551e90bd22fa1e8e7bbf
+        77d514d37947e2e6dbd0e1d0468c0bf71ae631823b3466634b0d4897218def3e
+        dc93f54e2e1b1cb5db37cb6cbb0425b7dd21b74d6ef2007fd5a333eb3bec1576
+        dd9f5a23dcaf6e2339d93751a7a9c2039b4766acd2c96d9239925f8ec9cd95de
+        2e826ecfda2e049128c2aba21b94d10b562502430656d0a486de81065a17656c
+        1c9e188317d9b545a29c4fda1d0ef99295e577e4bf76b1335381d1032877ec8d
+        f0e5f4b6ea97393ff773a824f7da508c509ae02ac458d56b6a173a588ec70e31
+        a78fda87fbf3af756d36dded740313d599b6db84a4316215e8aadd515d5f84b2
+        0e22c1a8f6ed7e1a5fdac403063f0f66f150fbf47b94687279d1b6af4c5bc519
+        342aa34249911a10c4207e8fde98fcdcfb04557379e8789a250b8f15d7a3df92
+        7931ec0500d24f8a9b7847dab0e8fa7ef6ceb015d8247d4e66eb8a52c143e5aa
+        5fb8443da10ba7b30b75ff7821e4d816a2d68b909b805669f8ac0af1ee40a66a
+        c2bb503135dc093fdb78f656218d37f5756633f0f6de6ec863f5473905ef153d
+        4fb3bcbb1773a8004eb35586d065b6f45f5100292e0727d62019d976167fa851
+        a1ae53f6132a926612ddab3d5d8ee6d673567f1adbd24bd3dc3aba980c599eee
+        a38a3cd62e3d2e8999
+    """.trimIndent()
+    final override val expectedPartialReadHash: String = """
+        0000000000000000000008f51e1d19bfa62e3885985f7568a5ea6381ff8a5747
+        85e3d231508a61918e19ad123bba13737db085f746320d1a6f8fdf175a374b86
+        e7b6575b1ce808d4e243e3c7acfd1b1a1f8634a68addc6003bf07b6e8b89f685
+        2c4c07214473b8d362c1fe94be9dce7a16fff8dfc60b81aee54bd17f106e6243
+        87898ede25492249e0ac6f98f643208066198a95e666d38342b5edb41d45e9a1
+        0d0e20134cbaab5bb9a32521b60d54296eb632c65a9f4b23b13aa48119d80000
+        0000000000000000
+    """.trimIndent()
+    final override val expectedUpdateSmallHash: String = """
+        08f51e1d19bfa62e3885985f7568a5ea6381ff8a574785e3d231508a61918e19
+        ad123bba13737db085f746320d1a6f8fdf175a374b86e7b6575b1ce808d4e243
+        e3c7acfd1b1a1f8634a68addc6003bf07b6e8b89f6852c4c07214473b8d362c1
+        fe94be9dce7a16fff8dfc60b81aee54bd17f106e624387898ede25492249e0ac
+        6f98f643208066198a95e666d38342b5edb41d45e9a10d0e20134cbaab5bb9a3
+        2521b60d54296eb632c65a9f4b23b13aa48119d8fd26a7eda18569b427fa3012
+        d53f1c3fac6d7a77819fe9e1d4def2c78ff780ebd6c1004f2b9210bc7ec2ded7
+        f291e9f7f25bafab071feff982a0503b53a81e365bf9b68c50a701ecac98463a
+        a0642a1e939008994c0465babe7916c4a391d3e146a84139397fd1176f045f58
+        e852bcb6220dbaf65fd1f0650ae4669123c16db0f42ff88ff7f03d204bb5fe73
+        6f8067147524cebc2ace3235081a96d58b5d4d8387ea1ddb0240bec8d009b5e2
+        7506cf42d24138da0c4ee74004b8cb2ed814abacc4f1d02718e45606d9df95f2
+        0b01c3c9d11b244ba677e6d018d9ba6e105c0986c6c4f3ae0c0e83d17758ae87
+        9d8b21e0098cb085bb352180c8356332779d1bb802c8f88215de8656504f9a29
+        6394a31fd56a814ac6b3db30937a5a1388de727058f92a47aab665b5c0228115
+        d1ad45d6ff9631c1a3d5fd2db72327c0c460a8cf7aa27e33d7c587c6e826d41f
+        923f70a97b63cca2e6f76694be23e334c19ec0a862f413c44097dff26ff757c0
+        c03c9969ddc34f2602ed7ad83ac7b57531d2029bf5258a2f752497ae5dd68b94
+        a5a9b2b2
+    """.trimIndent()
+    final override val expectedUpdateMediumHash: String = """
+        3fc525f00002cdb9a24e531a30afec39fe18ff9f4d01d160225864894adcb8fb
+        a0f645cb7a994c98caeab4fb5948c0b6c51c7fc0fcf2b212ad5228a03e67474b
+        869f7cd57965bc778e93c7383a3355493c609527b78a131ad9fee72385e0e5ed
+        1ec26cc442b20936020cc3ef322ec9d02a6e4c8516b084bb08c697634a9080e3
+        47a87c0ca608c98786358482207d69fdbcf246bd291dab0c06dfd17c6044d2ee
+        52111a561aad2c0dd2e805867e6b31c6fa3cececad587d103e8f1e0ea8965bae
+        e031b850fc63ca99cb7051ebda9fc43ea9fc7c0c64e6588ccbe1d5a6f2647fb3
+        c5db7a84bfc55efb54504f02ee765e546ffdcba165023b07e3364b52f27c0c64
+        dbb08cc2ce39dc73ed175c7957fcabcfe6d7a0ce6dc6295556235153686c5d67
+        e8b5e5bcc506f6855ce9238a59b45ef72420fb5ffa60f813556bafe2c14c2c18
+        e9aa2677f1e39792c53709c7c0f5e54018c3f3bcfb0bd6a6dda8c47beda09e18
+        db1f3339fa6efdb9efb70e066215b318a679534bab098dba472408fcef8356ca
+        ad45cb8395738189c491911bf55e832e202ddb7d9f43c92949d17fdd9429d3d4
+        4b8851f1ad8f8964fa7d38a524d7661b09356bf05f9b979f66bf813e6350bea3
+        195f31297e9c321a6ea2c01c21c77d55713adb9658a388a3b19e8a8a367b15ee
+        2542eeb510b9e4f885d33bd78370939990da96b819ab21dbcf9db315e74251dc
+        dc3e68b2e0fdbeda9bae03ca9e95173957b490524e46d44ccd6da50ff8e87eec
+        ade31acd2bad08eb82c67045c68bf829880e152d1007bd0fb83292c7db9be64e
+        c318b92113c215521dcc6e42b9be5f466c604c44164054fc99cc69330eb19153
+        0973f2d60022198370da16fe3709b0575bf94c4d3fbe11988b2c3e7bb0731247
+        fb02617f5031693236c33601bfdc41fdf5171dc94b300736b80c171f0c0b3e89
+        8266f6ac34cd4e907296801c6562359c95dfaa99fe16d4595cd6944c9b643d4f
+        0510f9693d92c0b2d7d423594a3603ad1227b2fe9f9e2c6c48cc7156e6b5b0a3
+        4dbf7936d5ddf52ce67219a922f99d0eb428887cc1e1aa60d18d8dcd069815ef
+        6a2595e7f0b0c893518be5aca7d21ef0d9ed9db8af4447b503460d203eab9a7e
+        c836cba07536398caf1139da3f4f66410245c96bac2caeb4020f3f419612f1da
+        77695b2af13ae0ce1721cde0ef030853563eb1c196c464acc8eeda3bf866080f
+        bbb477b13dba7c18ad8d7152ccdd1a4907f3f40fcac86c7b5b0839e4ac426a97
+        82b9978355fbeaecda44ce9e7cb60a703f916dcc48aa734f
+    """.trimIndent()
+
+}

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/TupleHash256UnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/TupleHash256UnitTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import kotlin.test.Test
+import org.kotlincrypto.core.Digest
+import org.kotlincrypto.hash.DigestUnitTest
+
+open class TupleHash256UnitTest: DigestUnitTest() {
+    override val digest: Digest = TupleHash256(null)
+    final override val expectedResetHash: String = "3afbba494aedd16073746e9a04ac28c3e7b023fed42bcb1935d26b0ce9ed212703448a3b08b8656bd32e5fdd3ebe72fb7575ab1eefa93b84286556bead103a0a"
+    final override val expectedMultiBlockHash: String = "82c91dea4a29848566ee147fafb20a008d5318829b9511e8f67481ea82669c5e74d68ac3270451558f98ff20b0023296fe131d13b1718208af2d4a12b2029d2b"
+    final override val expectedUpdateSmallHash: String = "40229c2938b049e6999139d01d43aaaed408d74801ca0304ed4d4b70c23b43b69fe0da06914bde2bc2d3f22f33ada4f94d51446bd75b8a435deb6b9e6b3cf69b"
+    final override val expectedUpdateMediumHash: String = "3436cb12063597f95cbe6dc7fbe2e99ddcf6906d9795de61a8b98ed1987801049d5d0791dc184638e861d128a8286fcf15132117556d670d780037e98c936e5f"
+
+    @Test
+    final override fun givenDigest_whenReset_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenReset_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenMultiBlockDigest_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenUpdatedSmall_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenUpdatedSmall_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenUpdatedMedium_thenDigestDigestReturnsExpected() {
+        super.givenDigest_whenUpdatedMedium_thenDigestDigestReturnsExpected()
+    }
+
+    @Test
+    final override fun givenDigest_whenCopied_thenIsDifferentInstance() {
+        super.givenDigest_whenCopied_thenIsDifferentInstance()
+    }
+
+    @Test
+    final override fun givenDigest_whenDigested_thenLengthMatchesOutput() {
+        super.givenDigest_whenDigested_thenLengthMatchesOutput()
+    }
+
+}

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/TupleHash256XofUnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/TupleHash256XofUnitTest.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import org.kotlincrypto.core.Updatable
+import org.kotlincrypto.core.Xof
+import org.kotlincrypto.hash.XofUnitTest
+import kotlin.test.Test
+
+open class TupleHash256XofUnitTest: XofUnitTest() {
+    override val xof: Updatable = TupleHash256.xOf()
+
+    override fun read(vararg args: ByteArray) {
+        (xof as Xof<*>).use { args.forEach { read(it) } }
+    }
+
+    override fun partialRead(out: ByteArray, offset: Int, len: Int) {
+        (xof as Xof<*>).use { read(out, offset, len) }
+    }
+
+    override fun reset() {
+        (xof as Xof<*>).reset()
+    }
+
+    @Test
+    final override fun givenXof_whenReset_thenReadReturnsExected() {
+        super.givenXof_whenReset_thenReadReturnsExected()
+    }
+
+    @Test
+    final override fun givenXof_whenPartialRead_thenReadReturnsExpected() {
+        super.givenXof_whenPartialRead_thenReadReturnsExpected()
+    }
+
+    @Test
+    final override fun givenXof_whenUpdatedSmall_thenReadReturnsExpected() {
+        super.givenXof_whenUpdatedSmall_thenReadReturnsExpected()
+    }
+
+    @Test
+    final override fun givenXof_whenUpdateMedium_thenReadReturnsExpected() {
+        super.givenXof_whenUpdateMedium_thenReadReturnsExpected()
+    }
+
+    final override val expectedResetHash: String = """
+        deb3fda5e2d09c28fbd3508a7173dcc1850024a4adb918aaef220116f0c2b6a6
+        efe6a8521a64fa3382ad465567fce2a799468ab6059633efc933d55b48184bb9
+        a3fe9fc2a930adcde5d00b40cfbbd55934e49ea65a5eae8b37b9674117d9316b
+        39983b186df4ad5c1fbaa94ecb3e98d6a82e27c4193341dfba6d7b57e3e6dc7b
+        7df1363f45b4e718438662ef26351593ef1d4a038f74bf5219d5938ee3592311
+        25b5a74e27be9e01e5d6b881fb4f8a36a318f3e7ed662961a021a0bfb0db41ed
+        f94342b5b415c9ec9e19194b3cb1097cad8df758f2b6bcb3d6d25e49671e3486
+        f28bb059829b46322fab43b15d993cb8512d4c8085c7214c360169916ac8722b
+        0e22bc26e7ec2e5a9663c25e00dd64b172dab8864989eb7c4c864c24f1a00efe
+        ae45563379d0b6edb6c2912079fe2128df3e953461b6b0a8612cb82a6a2386fc
+        cca63d2d259724787935a030fb8e9d7edc8cccd0c9a3df1239613dd0f2403397
+        e06ecbd00a963c431ef32e0db4142e360b7b50182468be5dcd23a8938b3bb68e
+        2e5a737c5b051dddf952b64de7fdd32757f31d71926b086f43d5052bea2a4f19
+        361f0fad5bc1df60a8c70f4f1d7f0a613136d52a9010429003e0c80586f1b847
+        45b392a81e340ba3a0f74dcb7036b1f406ae1c52da80f4f5124e6c81787c2a6f
+        e4f0c2e3f655430f9a5f83acb3413fc535ba3f34f3d71fd3f981ef9670781a1f
+        63a80c06c97450e7e65a491fccf1bd36f515b681c917bbdc345488d661089cb9
+        89a7e1d02457368c3636138cc6e0e3ef2f489e81e129201e3eaa6b254a49498a
+        d5f45114863a20d846b58c9afb6e83064274bfb0a80c29224c22ea4088851456
+        f94c1d3db1dd183cc46eb123832b63deb1dec464439d71a20f65a449395e3ea4
+        b96674fa83824615f50d4d38a799065327ece732dd06041fc6308665b76e4aeb
+        72b202e2160c1a5caedae1816b328979ba882c23892701d0105199a5a1993e8c
+        804e02f7ebcdcf9410972d8b4b4473d38c2df5f1fff626b7af748784062540b6
+        a723ce2aba42f56935da575b7e4fae174358db0ee0e461788b088c618ad04580
+        b248dbf7623fdf26335a839008737c42352f22ac636d91d5eb57a51c0d7ad8d5
+        30d6e015402d92eb62feedca34b9d8153893851839636996804f30914213900d
+        18116a3e9ae1e8f59f4fd5dc043264a64186b73b90612f96fd4ae1f83d84b4d8
+        8a1d725686909ac07f116054aff648b1ba27b0e6c770e724d8447e519f983374
+        85f77baf0f45f49741c55962585b03009f6696270d5de0bf4fb7f0370685c287
+        0acb0002474cc3e0b6c38cd5be0c04bc46106cb40ef71f59d4353ae8d65edf86
+        b8df05f5fe557dacc89bb9e5c2ac0a057285bb42962f637e7f1b5613b08c13fc
+        44a2125bd9fe94ecc7c0a6a4b0a135c9a4dae1f60f2ea6be8b85fb646aba8634
+        51ec5d47d52f9a85eac4436d6c4993b22af19f1d517e84916c98e45a6244c16d
+        dfe95f54a52aa8f42a4350d33bf79cb4af1d1ab1105a892dd38a9fbb8506fb0f
+        f0ad63a10eed1149d19383d74ab1e13d65f7f0395ee826638e99a7b7c70ab07c
+        da524c5288114dbcbec137c5a0c77bcb9487252a78108de84334537c4a286e1f
+        df71f22ef36357ebaa93361cf68c6534d4732a63a43eb57e7cf208d53b620ea7
+        9467f088fdf1a8a49488225a31e683a9a99068ae0eb7382faa17b59e043cf108
+        d5fac9a88ac835dd2f
+    """.trimIndent()
+    final override val expectedPartialReadHash: String = """
+        00000000000000000000688e00a39e4e9cd7545d53156d09c43718aca382d15e
+        bb4530ec8f85e8f5ce1a67b36168e71a33411a4a01125119914b064af9f10228
+        0e39c2f842dc65e7e6feb4ad3d182a1ae74ce2ef655122d3207781c4187919d8
+        a51013504d4a10cd21e83284c7a699f075ef147988a7e3c165bd35b7e957ac2e
+        dc801d1ce7704c0c62680b3b4ff13810ca7c68ce89dae2e0b1945b5ea0c5d76d
+        a39e4d8b4d8bc9ad100ebd04d7b8c18d5519e99f070b061f0bbbfed175390000
+        0000000000000000
+    """.trimIndent()
+    final override val expectedUpdateSmallHash: String = """
+        688e00a39e4e9cd7545d53156d09c43718aca382d15ebb4530ec8f85e8f5ce1a
+        67b36168e71a33411a4a01125119914b064af9f102280e39c2f842dc65e7e6fe
+        b4ad3d182a1ae74ce2ef655122d3207781c4187919d8a51013504d4a10cd21e8
+        3284c7a699f075ef147988a7e3c165bd35b7e957ac2edc801d1ce7704c0c6268
+        0b3b4ff13810ca7c68ce89dae2e0b1945b5ea0c5d76da39e4d8b4d8bc9ad100e
+        bd04d7b8c18d5519e99f070b061f0bbbfed175398b707efb65c0d4a38436bfff
+        f1ea897560aaa4df8b025d0c008ffdeb75fe8cc297218ab0e64180af4def60a4
+        6e65175518d885ee0ba117d7b5053c5bcf5cf85d0ceb8491ee4a57c7a3bc29da
+        f2601311d4905e09b509b04fc92a5e656f7ae8607edb7357019f12664d455d47
+        294a51d0a5b88c66432270884cc8768d54bcd3e92d850d3e0c749de0842c3bb3
+        def19ae97957ec1d3bedb641b5d321f482bff70bdbfd3fc97b08dd470ecf9edd
+        6eb8466a30d293ad9fc914dd4e2408c4896dac0bdf863353e85a90b8e243a693
+        5cbb81eb054b0ec99ed487aa613e430966b796b7646ac66717845a10957d0ead
+        d6f685313c729bc0f018b6644e47c6aadbaeced012164bca3434000db15f6bd7
+        64f75cae6300468f8514d6fd4428536de071e801f1950de9f3fdbd7824604c34
+        3d26ce23687484931a4f8793252ef57e69dd6be28f7ccb2c966ac364354403a4
+        bd08b2665fc3adb5f543f98e54b5d4faedbf8ed32a9acc0ee94630084e3a4a2f
+        387f1a254377ec174fe7ebcd0586c64d73c8a0a771be90e047c9657b988e0211
+        8de9004d
+    """.trimIndent()
+    final override val expectedUpdateMediumHash: String = """
+        4d30c31c8f640367b2c07ce385a2519b04a2afc18f996ad312ae2a7578b1eaf6
+        8319b42f1c0f8c55bb685572ab8ed61b96936c467ee48389cf6d9e7429c00807
+        13ae64d9465681a04d4c94325ca01ed214d6b2b58bed044be1df260704722ed0
+        9f7076d671d57575f63f21880059538cd6e6f48a12db9c58d0ea29d171db8d48
+        f47b90b119b087e62178ef62f6e88c4924c2787472590b6069176164e0439674
+        1e1d0b517ef15ded63d550bf3bc888147380b574b3b5cf7b7ab558338515b751
+        8853311f5eebf81d7c2855fc9171430be495edf90f9a84df081c6632c660c5c2
+        5bc2f91c73b35bb550cb15c09fdc7862d2761ab2b71553e7df1538c45d97f409
+        da02bbbbfa67d1e2e2bd514f4932d15d998053afd6ef2d77e3f9b4ead5279b79
+        e4992de56ecd08fcfb3145c851a17b17f394df9c9a17746f4ccd57b8b298b6b9
+        1d6781f41d32e1882e67918472fe1f0d8e22ff9c0c33963dea91d6f6083524f3
+        b7263977635360f5ad948c427bad13fbb33ecd4c3375350c3c68dbf33d6374f1
+        cfb11b9889c459566e9700757b467eefb3d0dcbb769a661cc76c596b2ac83ced
+        6a7fad23570f714bf0f7f8719022d5f2dbb74eca294506b6b379a0a4d68608fd
+        619dcf7573f1d31c82d62dbf04edca258674a4b5c18ba4828eca0ffa6fbf74ae
+        85d2bd780f2eec32caee2833b515b7af2baacbfaea0303d3e01b0f3735e1b851
+        dd32000443d2f1ce5c03a6a9c7a64270a2e99d7ad0571281ac996144d3c446e5
+        1e9889c1c4bdc1fc5908840346935a659ba8af9ce11973162acaffd65509dafa
+        fa010b62199a8f9c78b72574f39f83404c549459bc5c5281d0c63c0f244f6396
+        83bdc9e35ac8e2cf5716a1515cf86c892ab5e643e58b52c2127297935b29c5b5
+        c5b6d0b7c552b1dc553c07eedac4df251763a5dbabe1c13761b4cccbc1e8e108
+        b734ac9218aae7a84999f9d75ff8bb34d30a215c4da402dd16c3f659bf6be724
+        0c2e0051b89565cc7f0e41d5397e02876644c73f995f6137f543968329711b48
+        ed15f5d81187dc33941eda0f7b9a85412a94beef182adaaad051e444cc813118
+        d894a44adc230749e22f8a2d6b65260faf1baf57fd59ddbd0b81673ff4fcdc61
+        96034490860b4e763f81945f68cc12ead669f5478be55bd4d72d68d28e497302
+        39e8d0f9b976dd5d2f0a59e7f5a972b10aef16c0e0f78d2808b5bb5bef2c2dda
+        097ba0f6bc58aadcc9e3ccf317220d635f031b5f5717abdfbd10fbb5ddcec464
+        4419be6d9e1cb4ae536a7de95feb1c75b9505e040868546f
+    """.trimIndent()
+
+}

--- a/library/sha3/src/jvmTest/kotlin/org/kotlincrypto/hash/sha3/ParallelHash128JvmUnitTest.kt
+++ b/library/sha3/src/jvmTest/kotlin/org/kotlincrypto/hash/sha3/ParallelHash128JvmUnitTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import org.bouncycastle.crypto.digests.ParallelHash
+import org.kotlincrypto.core.Digest
+import org.kotlincrypto.hash.TestBCDigest
+import org.kotlincrypto.hash.TestJvmDigest
+
+class ParallelHash128JvmUnitTest: ParallelHash128UnitTest() {
+    override val digest: Digest = TestBCDigest(ParallelHash(128, null, B)) {
+        ParallelHash(this)
+    }
+
+    override fun givenDigest_whenCopied_thenIsDifferentInstance() {
+        // https://github.com/bcgit/bc-java/issues/1375
+//        super.givenDigest_whenCopied_thenIsDifferentInstance()
+    }
+}

--- a/library/sha3/src/jvmTest/kotlin/org/kotlincrypto/hash/sha3/ParallelHash128XofJvmUnitTest.kt
+++ b/library/sha3/src/jvmTest/kotlin/org/kotlincrypto/hash/sha3/ParallelHash128XofJvmUnitTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import org.bouncycastle.crypto.digests.ParallelHash
+import org.bouncycastle.crypto.digests.TupleHash
+import org.kotlincrypto.core.Updatable
+
+class ParallelHash128XofJvmUnitTest: ParallelHash128XofUnitTest() {
+    private val digest = ParallelHash(128, null, B)
+    override val xof: Updatable = object : Updatable {
+        override fun update(input: Byte) { digest.update(input) }
+        override fun update(input: ByteArray) { digest.update(input, 0, input.size) }
+        override fun update(input: ByteArray, offset: Int, len: Int) { digest.update(input, offset, len) }
+    }
+
+    override fun read(vararg args: ByteArray) {
+        args.forEach {
+            digest.doOutput(it, 0, it.size)
+        }
+    }
+
+    override fun partialRead(out: ByteArray, offset: Int, len: Int) {
+        digest.doOutput(out, offset, len)
+    }
+
+    override fun reset() {
+        digest.reset()
+    }
+
+}

--- a/library/sha3/src/jvmTest/kotlin/org/kotlincrypto/hash/sha3/ParallelHash256JvmUnitTest.kt
+++ b/library/sha3/src/jvmTest/kotlin/org/kotlincrypto/hash/sha3/ParallelHash256JvmUnitTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import org.bouncycastle.crypto.digests.ParallelHash
+import org.kotlincrypto.core.Digest
+import org.kotlincrypto.hash.TestBCDigest
+import org.kotlincrypto.hash.TestJvmDigest
+
+class ParallelHash256JvmUnitTest: ParallelHash256UnitTest() {
+    override val digest: Digest = TestBCDigest(ParallelHash(256, null, B)) {
+        ParallelHash(this)
+    }
+
+    override fun givenDigest_whenCopied_thenIsDifferentInstance() {
+        // https://github.com/bcgit/bc-java/issues/1375
+//        super.givenDigest_whenCopied_thenIsDifferentInstance()
+    }
+}

--- a/library/sha3/src/jvmTest/kotlin/org/kotlincrypto/hash/sha3/ParallelHash256XofJvmUnitTest.kt
+++ b/library/sha3/src/jvmTest/kotlin/org/kotlincrypto/hash/sha3/ParallelHash256XofJvmUnitTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import org.bouncycastle.crypto.digests.ParallelHash
+import org.bouncycastle.crypto.digests.TupleHash
+import org.kotlincrypto.core.Updatable
+
+class ParallelHash256XofJvmUnitTest: ParallelHash256XofUnitTest() {
+    private val digest = ParallelHash(256, null, B)
+    override val xof: Updatable = object : Updatable {
+        override fun update(input: Byte) { digest.update(input) }
+        override fun update(input: ByteArray) { digest.update(input, 0, input.size) }
+        override fun update(input: ByteArray, offset: Int, len: Int) { digest.update(input, offset, len) }
+    }
+
+    override fun read(vararg args: ByteArray) {
+        args.forEach {
+            digest.doOutput(it, 0, it.size)
+        }
+    }
+
+    override fun partialRead(out: ByteArray, offset: Int, len: Int) {
+        digest.doOutput(out, offset, len)
+    }
+
+    override fun reset() {
+        digest.reset()
+    }
+
+}

--- a/library/sha3/src/jvmTest/kotlin/org/kotlincrypto/hash/sha3/TupleHash128JvmUnitTest.kt
+++ b/library/sha3/src/jvmTest/kotlin/org/kotlincrypto/hash/sha3/TupleHash128JvmUnitTest.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import org.kotlincrypto.core.Digest
+import org.kotlincrypto.hash.TestJvmDigest
+
+class TupleHash128JvmUnitTest: TupleHash128UnitTest() {
+    override val digest: Digest = TestJvmDigest(super.digest)
+}

--- a/library/sha3/src/jvmTest/kotlin/org/kotlincrypto/hash/sha3/TupleHash128XofJvmUnitTest.kt
+++ b/library/sha3/src/jvmTest/kotlin/org/kotlincrypto/hash/sha3/TupleHash128XofJvmUnitTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import org.bouncycastle.crypto.digests.TupleHash
+import org.kotlincrypto.core.Updatable
+
+class TupleHash128XofJvmUnitTest: TupleHash128XofUnitTest() {
+    private val digest = TupleHash(128, null)
+    override val xof: Updatable = object : Updatable {
+        override fun update(input: Byte) { digest.update(input) }
+        override fun update(input: ByteArray) { digest.update(input, 0, input.size) }
+        override fun update(input: ByteArray, offset: Int, len: Int) { digest.update(input, offset, len) }
+    }
+
+    override fun read(vararg args: ByteArray) {
+        args.forEach {
+            digest.doOutput(it, 0, it.size)
+        }
+    }
+
+    override fun partialRead(out: ByteArray, offset: Int, len: Int) {
+        digest.doOutput(out, offset, len)
+    }
+
+    override fun reset() {
+        digest.reset()
+    }
+
+}

--- a/library/sha3/src/jvmTest/kotlin/org/kotlincrypto/hash/sha3/TupleHash256JvmUnitTest.kt
+++ b/library/sha3/src/jvmTest/kotlin/org/kotlincrypto/hash/sha3/TupleHash256JvmUnitTest.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import org.kotlincrypto.core.Digest
+import org.kotlincrypto.hash.TestJvmDigest
+
+class TupleHash256JvmUnitTest: TupleHash256UnitTest() {
+    override val digest: Digest = TestJvmDigest(super.digest)
+}

--- a/library/sha3/src/jvmTest/kotlin/org/kotlincrypto/hash/sha3/TupleHash256XofJvmUnitTest.kt
+++ b/library/sha3/src/jvmTest/kotlin/org/kotlincrypto/hash/sha3/TupleHash256XofJvmUnitTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import org.bouncycastle.crypto.digests.TupleHash
+import org.kotlincrypto.core.Updatable
+
+class TupleHash256XofJvmUnitTest: TupleHash256XofUnitTest() {
+    private val digest = TupleHash(256, null)
+    override val xof: Updatable = object : Updatable {
+        override fun update(input: Byte) { digest.update(input) }
+        override fun update(input: ByteArray) { digest.update(input, 0, input.size) }
+        override fun update(input: ByteArray, offset: Int, len: Int) { digest.update(input, offset, len) }
+    }
+
+    override fun read(vararg args: ByteArray) {
+        args.forEach {
+            digest.doOutput(it, 0, it.size)
+        }
+    }
+
+    override fun partialRead(out: ByteArray, offset: Int, len: Int) {
+        digest.doOutput(out, offset, len)
+    }
+
+    override fun reset() {
+        digest.reset()
+    }
+
+}

--- a/tools/testing/src/commonMain/kotlin/org/kotlincrypto/hash/DigestUnitTest.kt
+++ b/tools/testing/src/commonMain/kotlin/org/kotlincrypto/hash/DigestUnitTest.kt
@@ -65,8 +65,10 @@ abstract class DigestUnitTest: HashUnitTest() {
         updateSmall(digest)
         assertNotEquals(copy, digest)
         assertEquals(expectedResetHash, copy.digest().encodeToString(TestData.base16))
+
+        updateSmall(copy)
         assertEquals(expectedUpdateSmallHash, digest.digest().encodeToString(TestData.base16))
-        assertEquals(expectedUpdateSmallHash, copy.digest(TestData.BYTES_SMALL).encodeToString(TestData.base16))
+        assertEquals(expectedUpdateSmallHash, copy.digest().encodeToString(TestData.base16))
     }
 
     open fun givenDigest_whenDigested_thenLengthMatchesOutput() {

--- a/tools/testing/src/commonMain/kotlin/org/kotlincrypto/hash/HashUnitTest.kt
+++ b/tools/testing/src/commonMain/kotlin/org/kotlincrypto/hash/HashUnitTest.kt
@@ -28,6 +28,12 @@ abstract class HashUnitTest {
         }
 
         fun updateMedium(updatable: Updatable) {
+            // Some algorithms don't discard 0 length input, effecting
+            // the end result (e.g. TupleHash). This ensures that, if
+            // that's the case, it is exercised in testing.
+            updatable.update(TestData.BYTES_EMPTY)
+            updatable.update(TestData.BYTES_EMPTY, 0, TestData.BYTES_EMPTY.size)
+
             updatable.update(TestData.BYTES_MEDIUM[0])
             updatable.update(TestData.BYTES_MEDIUM)
             updatable.update(TestData.BYTES_MEDIUM, 100, 1_000)

--- a/tools/testing/src/commonMain/kotlin/org/kotlincrypto/hash/TestData.kt
+++ b/tools/testing/src/commonMain/kotlin/org/kotlincrypto/hash/TestData.kt
@@ -25,6 +25,8 @@ internal object TestData {
     internal val base16 = Base16 { encodeToLowercase = true }
     internal val base64 = Base64 { lineBreakInterval = 64 }
 
+    internal val BYTES_EMPTY = ByteArray(0)
+
     // 50 bytes
     internal val BYTES_SMALL: ByteArray = """
         jIV557p7t4uY4z1u2YX3XgNd0Q/MWkSG9rR8hnbS/betAxGQ39Jfn3/P4/jp5Vy1

--- a/tools/testing/src/jvmMain/kotlin/org/kotlincrypto/hash/TestBCDigest.kt
+++ b/tools/testing/src/jvmMain/kotlin/org/kotlincrypto/hash/TestBCDigest.kt
@@ -20,6 +20,7 @@ package org.kotlincrypto.hash
 import org.kotlincrypto.core.Digest
 import org.kotlincrypto.core.InternalKotlinCryptoApi
 import org.kotlincrypto.core.internal.DigestState
+import java.lang.IllegalStateException
 
 @OptIn(InternalKotlinCryptoApi::class)
 class TestBCDigest<T: org.bouncycastle.crypto.ExtendedDigest>: Digest {
@@ -47,14 +48,16 @@ class TestBCDigest<T: org.bouncycastle.crypto.ExtendedDigest>: Digest {
 
     override fun copy(state: DigestState): Digest = TestBCDigest<T>(state, this)
 
-    override fun compress(input: ByteArray, offset: Int) { delegate.update(input, offset, blockSize()) }
+    override fun compress(input: ByteArray, offset: Int) { throw IllegalStateException("update is overridden...") }
 
     override fun digest(bitLength: Long, bufferOffset: Int, buffer: ByteArray): ByteArray {
-        delegate.update(buffer, 0, bufferOffset)
         val out = ByteArray(digestLength())
         delegate.doFinal(out, 0)
         return out
     }
+
+    override fun updateDigest(input: Byte) { delegate.update(input) }
+    override fun updateDigest(input: ByteArray, offset: Int, len: Int) { delegate.update(input, offset, len) }
 
     override fun resetDigest() { delegate.reset() }
 }

--- a/tools/testing/src/jvmMain/kotlin/org/kotlincrypto/hash/TestJvmDigest.kt
+++ b/tools/testing/src/jvmMain/kotlin/org/kotlincrypto/hash/TestJvmDigest.kt
@@ -21,6 +21,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.kotlincrypto.core.Digest
 import org.kotlincrypto.core.InternalKotlinCryptoApi
 import org.kotlincrypto.core.internal.DigestState
+import java.lang.IllegalStateException
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import java.security.Security
@@ -40,11 +41,7 @@ class TestJvmDigest: Digest {
     private constructor(
         digest: MessageDigest,
         blockSize: Int
-    ): super(
-        digest.algorithm,
-        blockSize,
-        digest.digestLength
-    ) {
+    ): super(digest.algorithm, blockSize, digest.digestLength) {
         delegate = digest
     }
 
@@ -57,12 +54,13 @@ class TestJvmDigest: Digest {
 
     override fun copy(state: DigestState): Digest = TestJvmDigest(state, this)
 
-    override fun compress(input: ByteArray, offset: Int) { delegate.update(input, offset, blockSize()) }
+    override fun compress(input: ByteArray, offset: Int) { throw IllegalStateException("update is overridden...") }
 
-    override fun digest(bitLength: Long, bufferOffset: Int, buffer: ByteArray): ByteArray {
-        delegate.update(buffer, 0, bufferOffset)
-        return delegate.digest()
-    }
+    override fun digest(bitLength: Long, bufferOffset: Int, buffer: ByteArray): ByteArray = delegate.digest()
+
+    override fun updateDigest(input: Byte) { delegate.update(input) }
+
+    override fun updateDigest(input: ByteArray, offset: Int, len: Int) { delegate.update(input, offset, len) }
 
     override fun resetDigest() { delegate.reset() }
 


### PR DESCRIPTION
Closes #37 

This PR:
 - Adds remaining `sha3` functions from [NIST.SP.800-185](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf), `ParallelHash` and `TupleHash`.
 - Updates `core` to `0.2.4-SNAPSHOT`
     - Release is protected as the root `build.gradle.kts` file will **NOT** add the Maven snapshot repo if `hash` version is a non-`SNAPSHOT` (i.e. a release version), resulting in a build failure.