### PR TITLE
Add constructors for configuring non-default output byte length

### DIFF
--- a/library/sha3/api/sha3.api
+++ b/library/sha3/api/sha3.api
@@ -3,7 +3,8 @@ public final class org/kotlincrypto/hash/sha3/CSHAKE128 : org/kotlincrypto/hash/
 	public static final field Companion Lorg/kotlincrypto/hash/sha3/CSHAKE128$Companion;
 	public static final field DIGEST_LENGTH I
 	public fun <init> ([B[B)V
-	public synthetic fun <init> ([B[BZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([B[BI)V
+	public synthetic fun <init> ([B[BIZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun xOf ([B[B)Lorg/kotlincrypto/core/Xof;
 }
 
@@ -16,7 +17,8 @@ public final class org/kotlincrypto/hash/sha3/CSHAKE256 : org/kotlincrypto/hash/
 	public static final field Companion Lorg/kotlincrypto/hash/sha3/CSHAKE256$Companion;
 	public static final field DIGEST_LENGTH I
 	public fun <init> ([B[B)V
-	public synthetic fun <init> ([B[BZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([B[BI)V
+	public synthetic fun <init> ([B[BIZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun xOf ([B[B)Lorg/kotlincrypto/core/Xof;
 }
 
@@ -65,7 +67,8 @@ public abstract class org/kotlincrypto/hash/sha3/ParallelDigest : org/kotlincryp
 public final class org/kotlincrypto/hash/sha3/ParallelHash128 : org/kotlincrypto/hash/sha3/ParallelDigest {
 	public static final field Companion Lorg/kotlincrypto/hash/sha3/ParallelHash128$Companion;
 	public fun <init> ([BI)V
-	public synthetic fun <init> ([BIZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([BII)V
+	public synthetic fun <init> ([BIIZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun xOf ([BI)Lorg/kotlincrypto/core/Xof;
 }
 
@@ -76,7 +79,8 @@ public final class org/kotlincrypto/hash/sha3/ParallelHash128$Companion : org/ko
 public final class org/kotlincrypto/hash/sha3/ParallelHash256 : org/kotlincrypto/hash/sha3/ParallelDigest {
 	public static final field Companion Lorg/kotlincrypto/hash/sha3/ParallelHash256$Companion;
 	public fun <init> ([BI)V
-	public synthetic fun <init> ([BIZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([BII)V
+	public synthetic fun <init> ([BIIZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun xOf ([BI)Lorg/kotlincrypto/core/Xof;
 }
 
@@ -103,7 +107,8 @@ public final class org/kotlincrypto/hash/sha3/SHA3_512 : org/kotlincrypto/hash/s
 public final class org/kotlincrypto/hash/sha3/SHAKE128 : org/kotlincrypto/hash/sha3/SHAKEDigest {
 	public static final field Companion Lorg/kotlincrypto/hash/sha3/SHAKE128$Companion;
 	public fun <init> ()V
-	public synthetic fun <init> (ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (I)V
+	public synthetic fun <init> (IZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun xOf ()Lorg/kotlincrypto/core/Xof;
 }
 
@@ -114,7 +119,8 @@ public final class org/kotlincrypto/hash/sha3/SHAKE128$Companion : org/kotlincry
 public final class org/kotlincrypto/hash/sha3/SHAKE256 : org/kotlincrypto/hash/sha3/SHAKEDigest {
 	public static final field Companion Lorg/kotlincrypto/hash/sha3/SHAKE256$Companion;
 	public fun <init> ()V
-	public synthetic fun <init> (ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (I)V
+	public synthetic fun <init> (IZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun xOf ()Lorg/kotlincrypto/core/Xof;
 }
 
@@ -124,7 +130,6 @@ public final class org/kotlincrypto/hash/sha3/SHAKE256$Companion : org/kotlincry
 
 public abstract class org/kotlincrypto/hash/sha3/SHAKEDigest : org/kotlincrypto/hash/sha3/KeccakDigest, org/kotlincrypto/core/XofAlgorithm {
 	protected static final field Companion Lorg/kotlincrypto/hash/sha3/SHAKEDigest$Companion;
-	protected final field xOfMode Z
 	public synthetic fun <init> (Lorg/kotlincrypto/core/internal/DigestState;Lorg/kotlincrypto/hash/sha3/SHAKEDigest;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> ([B[BZLjava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final synthetic fun blockSizeFromBitStrength$sha3 (I)I
@@ -156,7 +161,8 @@ public abstract class org/kotlincrypto/hash/sha3/TupleDigest : org/kotlincrypto/
 public final class org/kotlincrypto/hash/sha3/TupleHash128 : org/kotlincrypto/hash/sha3/TupleDigest {
 	public static final field Companion Lorg/kotlincrypto/hash/sha3/TupleHash128$Companion;
 	public fun <init> ([B)V
-	public synthetic fun <init> ([BZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([BI)V
+	public synthetic fun <init> ([BIZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun xOf ()Lorg/kotlincrypto/core/Xof;
 	public static final fun xOf ([B)Lorg/kotlincrypto/core/Xof;
 }
@@ -170,7 +176,8 @@ public final class org/kotlincrypto/hash/sha3/TupleHash128$Companion : org/kotli
 public final class org/kotlincrypto/hash/sha3/TupleHash256 : org/kotlincrypto/hash/sha3/TupleDigest {
 	public static final field Companion Lorg/kotlincrypto/hash/sha3/TupleHash256$Companion;
 	public fun <init> ([B)V
-	public synthetic fun <init> ([BZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([BI)V
+	public synthetic fun <init> ([BIZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun xOf ()Lorg/kotlincrypto/core/Xof;
 	public static final fun xOf ([B)Lorg/kotlincrypto/core/Xof;
 }

--- a/library/sha3/api/sha3.api
+++ b/library/sha3/api/sha3.api
@@ -69,10 +69,12 @@ public final class org/kotlincrypto/hash/sha3/ParallelHash128 : org/kotlincrypto
 	public fun <init> ([BI)V
 	public fun <init> ([BII)V
 	public synthetic fun <init> ([BIIZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun xOf (I)Lorg/kotlincrypto/core/Xof;
 	public static final fun xOf ([BI)Lorg/kotlincrypto/core/Xof;
 }
 
 public final class org/kotlincrypto/hash/sha3/ParallelHash128$Companion : org/kotlincrypto/hash/sha3/SHAKEDigest$SHAKEXofFactory {
+	public final fun xOf (I)Lorg/kotlincrypto/core/Xof;
 	public final fun xOf ([BI)Lorg/kotlincrypto/core/Xof;
 }
 
@@ -81,10 +83,12 @@ public final class org/kotlincrypto/hash/sha3/ParallelHash256 : org/kotlincrypto
 	public fun <init> ([BI)V
 	public fun <init> ([BII)V
 	public synthetic fun <init> ([BIIZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun xOf (I)Lorg/kotlincrypto/core/Xof;
 	public static final fun xOf ([BI)Lorg/kotlincrypto/core/Xof;
 }
 
 public final class org/kotlincrypto/hash/sha3/ParallelHash256$Companion : org/kotlincrypto/hash/sha3/SHAKEDigest$SHAKEXofFactory {
+	public final fun xOf (I)Lorg/kotlincrypto/core/Xof;
 	public final fun xOf ([BI)Lorg/kotlincrypto/core/Xof;
 }
 

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/CSHAKE128.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/CSHAKE128.kt
@@ -30,8 +30,8 @@ import kotlin.jvm.JvmStatic
 public class CSHAKE128: SHAKEDigest {
 
     /**
-     * Primary constructor for creating a new [CSHAKE128] [Digest]
-     * instance with a fixed output [digestLength].
+     * Creates a new [CSHAKE128] [Digest] instance with a default output length
+     * of 32 bytes.
      *
      * @param [N] A function-name bit string, used by NIST to define functions
      *   based on CSHAKE. Usage should be avoided when not required.
@@ -42,13 +42,32 @@ public class CSHAKE128: SHAKEDigest {
     public constructor(
         N: ByteArray?,
         S: ByteArray?,
-    ): this(N, S, xOfMode = false)
+    ): this(N, S, DIGEST_LENGTH)
+
+    /**
+     * Creates a new [CSHAKE128] [Digest] instance with a non-default output length.
+     *
+     * @param [N] A function-name bit string, used by NIST to define functions
+     *   based on CSHAKE. Usage should be avoided when not required.
+     * @param [S] A user selected customization bit string to define a variant
+     *   of the function. When no customization is desired, [S] is set to an
+     *   empty or null value. (e.g. "My Customization".encodeToByteArray())
+     * @param [outputLength] The number of bytes returned when [digest] is invoked
+     * @throws [IllegalArgumentException] If [outputLength] is negative
+     * */
+    @Throws(IllegalArgumentException::class)
+    public constructor(
+        N: ByteArray?,
+        S: ByteArray?,
+        outputLength: Int,
+    ): this(N, S, outputLength, xOfMode = false)
 
     private constructor(
         N: ByteArray?,
         S: ByteArray?,
+        outputLength: Int,
         xOfMode: Boolean,
-    ): super(N, S, xOfMode, CSHAKE + BIT_STRENGTH_128, BLOCK_SIZE, DIGEST_LENGTH)
+    ): super(N, S, xOfMode, CSHAKE + BIT_STRENGTH_128, BLOCK_SIZE, outputLength)
 
     private constructor(state: DigestState, digest: CSHAKE128): super(state, digest)
 
@@ -62,7 +81,7 @@ public class CSHAKE128: SHAKEDigest {
         public const val BLOCK_SIZE: Int = BLOCK_SIZE_BIT_128
 
         /**
-         * The default number of bytes output when [digest] is called
+         * The default number of bytes output when [digest] is invoked
          * */
         public const val DIGEST_LENGTH: Int = DIGEST_LENGTH_BIT_128
 
@@ -76,6 +95,6 @@ public class CSHAKE128: SHAKEDigest {
          *   empty or null value. (e.g. "My Customization".encodeToByteArray())
          * */
         @JvmStatic
-        public fun xOf(N: ByteArray?, S: ByteArray?): Xof<CSHAKE128> = SHAKEXof(CSHAKE128(N, S, xOfMode = true))
+        public fun xOf(N: ByteArray?, S: ByteArray?): Xof<CSHAKE128> = SHAKEXof(CSHAKE128(N, S, 0, xOfMode = true))
     }
 }

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/CSHAKE256.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/CSHAKE256.kt
@@ -30,8 +30,8 @@ import kotlin.jvm.JvmStatic
 public class CSHAKE256: SHAKEDigest {
 
     /**
-     * Primary constructor for creating a new [CSHAKE256] [Digest]
-     * instance with a fixed output [digestLength].
+     * Creates a new [CSHAKE256] [Digest] instance with a default output length
+     * of 64 bytes.
      *
      * @param [N] A function-name bit string, used by NIST to define functions
      *   based on CSHAKE. Usage should be avoided when not required.
@@ -42,13 +42,32 @@ public class CSHAKE256: SHAKEDigest {
     public constructor(
         N: ByteArray?,
         S: ByteArray?,
-    ): this(N, S, xOfMode = false)
+    ): this(N, S, DIGEST_LENGTH)
+
+    /**
+     * Creates a new [CSHAKE256] [Digest] instance with a non-default output length.
+     *
+     * @param [N] A function-name bit string, used by NIST to define functions
+     *   based on CSHAKE. Usage should be avoided when not required.
+     * @param [S] A user selected customization bit string to define a variant
+     *   of the function. When no customization is desired, [S] is set to an
+     *   empty or null value. (e.g. "My Customization".encodeToByteArray())
+     * @param [outputLength] The number of bytes returned when [digest] is invoked
+     * @throws [IllegalArgumentException] If [outputLength] is negative
+     * */
+    @Throws(IllegalArgumentException::class)
+    public constructor(
+        N: ByteArray?,
+        S: ByteArray?,
+        outputLength: Int,
+    ): this(N, S, outputLength, xOfMode = false)
 
     private constructor(
         N: ByteArray?,
         S: ByteArray?,
+        outputLength: Int,
         xOfMode: Boolean,
-    ): super(N, S, xOfMode, CSHAKE + BIT_STRENGTH_256, BLOCK_SIZE, DIGEST_LENGTH)
+    ): super(N, S, xOfMode, CSHAKE + BIT_STRENGTH_256, BLOCK_SIZE, outputLength)
 
     private constructor(state: DigestState, digest: CSHAKE256): super(state, digest)
 
@@ -62,7 +81,7 @@ public class CSHAKE256: SHAKEDigest {
         public const val BLOCK_SIZE: Int = BLOCK_SIZE_BIT_256
 
         /**
-         * The default number of bytes output when [digest] is called
+         * The default number of bytes output when [digest] is invoked
          * */
         public const val DIGEST_LENGTH: Int = DIGEST_LENGTH_BIT_256
 
@@ -76,6 +95,6 @@ public class CSHAKE256: SHAKEDigest {
          *   empty or null value. (e.g. "My Customization".encodeToByteArray())
          * */
         @JvmStatic
-        public fun xOf(N: ByteArray?, S: ByteArray?): Xof<CSHAKE256> = SHAKEXof(CSHAKE256(N, S, xOfMode = true))
+        public fun xOf(N: ByteArray?, S: ByteArray?): Xof<CSHAKE256> = SHAKEXof(CSHAKE256(N, S, 0, xOfMode = true))
     }
 }

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/ParallelDigest.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/ParallelDigest.kt
@@ -88,9 +88,7 @@ public sealed class ParallelDigest: SHAKEDigest {
         }
 
         @OptIn(InternalKotlinCryptoApi::class)
-        val final = buffered +
-                Xof.Utils.rightEncode(processCount) +
-                Xof.Utils.rightEncode(if (xOfMode) 0L else digestLength() * 8L)
+        val final = buffered + Xof.Utils.rightEncode(processCount) + Xof.Utils.rightEncode(digestLength() * 8L)
 
         val size = bufferOffset + final.size
         val newBitLength = bitLength + (final.size * 8)

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/ParallelHash128.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/ParallelHash128.kt
@@ -80,6 +80,16 @@ public class ParallelHash128: ParallelDigest {
         /**
          * Produces a new [Xof] (Extendable-Output Function) for [ParallelHash128]
          *
+         * @param [B] The block size for the inner hash function in bytes
+         * @throws [IllegalArgumentException] If [B] is less than 1
+         * */
+        @JvmStatic
+        @Throws(IllegalArgumentException::class)
+        public fun xOf(B: Int): Xof<ParallelHash128> = xOf(null, B)
+
+        /**
+         * Produces a new [Xof] (Extendable-Output Function) for [ParallelHash128]
+         *
          * @param [S] A user selected customization bit string to define a variant
          *   of the function. When no customization is desired, [S] is set to an
          *   empty or null value. (e.g. "My Customization".encodeToByteArray())

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/ParallelHash128.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/ParallelHash128.kt
@@ -30,8 +30,8 @@ import kotlin.jvm.JvmStatic
 public class ParallelHash128: ParallelDigest {
 
     /**
-     * Creates a new [ParallelHash128] [Digest] instance with a fixed output
-     * [digestLength].
+     * Creates a new [ParallelHash128] [Digest] instance with a default output
+     * length of 32 bytes.
      *
      * @param [S] A user selected customization bit string to define a variant
      *   of the function. When no customization is desired, [S] is set to an
@@ -40,13 +40,36 @@ public class ParallelHash128: ParallelDigest {
      * @throws [IllegalArgumentException] If [B] is less than 1
      * */
     @Throws(IllegalArgumentException::class)
-    public constructor(S: ByteArray?, B: Int): this(S, B, xOfMode = false)
+    public constructor(
+        S: ByteArray?,
+        B: Int,
+    ): this(S, B, DIGEST_LENGTH_BIT_128)
+
+    /**
+     * Creates a new [ParallelHash128] [Digest] instance with a non-default output
+     * length.
+     *
+     * @param [S] A user selected customization bit string to define a variant
+     *   of the function. When no customization is desired, [S] is set to an
+     *   empty or null value. (e.g. "My Customization".encodeToByteArray())
+     * @param [B] The block size for the inner hash function in bytes
+     * @param [outputLength] The number of bytes returned when [digest] is invoked
+     * @throws [IllegalArgumentException] If [B] is less than 1, or [outputLength]
+     *   is negative
+     * */
+    @Throws(IllegalArgumentException::class)
+    public constructor(
+        S: ByteArray?,
+        B: Int,
+        outputLength: Int,
+    ): this(S, B, outputLength, xOfMode = false)
 
     private constructor(
         S: ByteArray?,
         B: Int,
+        outputLength: Int,
         xOfMode: Boolean,
-    ): super(S, B, xOfMode, BIT_STRENGTH_128, DIGEST_LENGTH_BIT_128)
+    ): super(S, B, xOfMode, BIT_STRENGTH_128, outputLength)
 
     private constructor(state: DigestState, digest: ParallelHash128): super(state, digest)
 
@@ -65,6 +88,6 @@ public class ParallelHash128: ParallelDigest {
          * */
         @JvmStatic
         @Throws(IllegalArgumentException::class)
-        public fun xOf(S: ByteArray?, B: Int): Xof<ParallelHash128> = SHAKEXof(ParallelHash128(S, B, xOfMode = true))
+        public fun xOf(S: ByteArray?, B: Int): Xof<ParallelHash128> = SHAKEXof(ParallelHash128(S, B, 0, xOfMode = true))
     }
 }

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/ParallelHash256.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/ParallelHash256.kt
@@ -30,8 +30,8 @@ import kotlin.jvm.JvmStatic
 public class ParallelHash256: ParallelDigest {
 
     /**
-     * Creates a new [ParallelHash256] [Digest] instance with a fixed output
-     * [digestLength].
+     * Creates a new [ParallelHash256] [Digest] instance with a default output
+     * length of 64 bytes.
      *
      * @param [S] A user selected customization bit string to define a variant
      *   of the function. When no customization is desired, [S] is set to an
@@ -40,13 +40,36 @@ public class ParallelHash256: ParallelDigest {
      * @throws [IllegalArgumentException] If [B] is less than 1
      * */
     @Throws(IllegalArgumentException::class)
-    public constructor(S: ByteArray?, B: Int): this(S, B, xOfMode = false)
+    public constructor(
+        S: ByteArray?,
+        B: Int,
+    ): this(S, B, DIGEST_LENGTH_BIT_256)
+
+    /**
+     * Creates a new [ParallelHash256] [Digest] instance with a non-default output
+     * length.
+     *
+     * @param [S] A user selected customization bit string to define a variant
+     *   of the function. When no customization is desired, [S] is set to an
+     *   empty or null value. (e.g. "My Customization".encodeToByteArray())
+     * @param [B] The block size for the inner hash function in bytes
+     * @param [outputLength] The number of bytes returned when [digest] is invoked
+     * @throws [IllegalArgumentException] If [B] is less than 1, or [outputLength]
+     *   is negative
+     * */
+    @Throws(IllegalArgumentException::class)
+    public constructor(
+        S: ByteArray?,
+        B: Int,
+        outputLength: Int,
+    ): this(S, B, outputLength, xOfMode = false)
 
     private constructor(
         S: ByteArray?,
         B: Int,
+        outputLength: Int,
         xOfMode: Boolean,
-    ): super(S, B, xOfMode, BIT_STRENGTH_256, DIGEST_LENGTH_BIT_256)
+    ): super(S, B, xOfMode, BIT_STRENGTH_256, outputLength)
 
     private constructor(state: DigestState, digest: ParallelHash256): super(state, digest)
 
@@ -65,6 +88,6 @@ public class ParallelHash256: ParallelDigest {
          * */
         @JvmStatic
         @Throws(IllegalArgumentException::class)
-        public fun xOf(S: ByteArray?, B: Int): Xof<ParallelHash256> = SHAKEXof(ParallelHash256(S, B, xOfMode = true))
+        public fun xOf(S: ByteArray?, B: Int): Xof<ParallelHash256> = SHAKEXof(ParallelHash256(S, B, 0, xOfMode = true))
     }
 }

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/ParallelHash256.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/ParallelHash256.kt
@@ -80,6 +80,16 @@ public class ParallelHash256: ParallelDigest {
         /**
          * Produces a new [Xof] (Extendable-Output Function) for [ParallelHash256]
          *
+         * @param [B] The block size for the inner hash function in bytes
+         * @throws [IllegalArgumentException] If [B] is less than 1
+         * */
+        @JvmStatic
+        @Throws(IllegalArgumentException::class)
+        public fun xOf(B: Int): Xof<ParallelHash256> = xOf(null, B)
+
+        /**
+         * Produces a new [Xof] (Extendable-Output Function) for [ParallelHash256]
+         *
          * @param [S] A user selected customization bit string to define a variant
          *   of the function. When no customization is desired, [S] is set to an
          *   empty or null value. (e.g. "My Customization".encodeToByteArray())

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/SHAKE128.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/SHAKE128.kt
@@ -30,14 +30,27 @@ import kotlin.jvm.JvmStatic
 public class SHAKE128: SHAKEDigest {
 
     /**
-     * Primary constructor for creating a new [SHAKE128] [Digest]
-     * instance with a fixed output [digestLength].
+     * Creates a new [SHAKE128] [Digest] instance with a default output
+     * length of 32 bytes.
      * */
-    public constructor(): this(xOfMode = false)
+    public constructor(): this(DIGEST_LENGTH_BIT_128)
+
+    /**
+     * Creates a new [SHAKE128] [Digest] instance with a non-default output
+     * length.
+     *
+     * @param [outputLength] The number of bytes returned when [digest] is invoked
+     * @throws [IllegalArgumentException] If [outputLength] is negative
+     * */
+    @Throws(IllegalArgumentException::class)
+    public constructor(
+        outputLength: Int,
+    ): this(outputLength, xOfMode = false)
 
     private constructor(
-        xOfMode: Boolean
-    ): super(null, null, xOfMode, SHAKE + BIT_STRENGTH_128, BLOCK_SIZE_BIT_128, DIGEST_LENGTH_BIT_128)
+        outputLength: Int,
+        xOfMode: Boolean,
+    ): super(null, null, xOfMode, SHAKE + BIT_STRENGTH_128, BLOCK_SIZE_BIT_128, outputLength)
 
     private constructor(state: DigestState, digest: SHAKE128): super(state, digest)
 
@@ -49,6 +62,6 @@ public class SHAKE128: SHAKEDigest {
          * Produces a new [Xof] (Extendable-Output Function) for [SHAKE128]
          * */
         @JvmStatic
-        public fun xOf(): Xof<SHAKE128> = SHAKEXof(SHAKE128(xOfMode = true))
+        public fun xOf(): Xof<SHAKE128> = SHAKEXof(SHAKE128(0, xOfMode = true))
     }
 }

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/SHAKE256.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/SHAKE256.kt
@@ -30,14 +30,27 @@ import kotlin.jvm.JvmStatic
 public class SHAKE256: SHAKEDigest {
 
     /**
-     * Primary constructor for creating a new [SHAKE256] [Digest]
-     * instance with a fixed output [digestLength].
+     * Creates a new [SHAKE256] [Digest] instance with a default output
+     * length of 64 bytes.
      * */
-    public constructor(): this(xOfMode = false)
+    public constructor(): this(DIGEST_LENGTH_BIT_256)
+
+    /**
+     * Creates a new [SHAKE256] [Digest] instance with a non-default output
+     * length.
+     *
+     * @param [outputLength] The number of bytes returned when [digest] is invoked
+     * @throws [IllegalArgumentException] If [outputLength] is negative
+     * */
+    @Throws(IllegalArgumentException::class)
+    public constructor(
+        outputLength: Int,
+    ): this(outputLength, xOfMode = false)
 
     private constructor(
+        outputLength: Int,
         xOfMode: Boolean
-    ): super(null, null, xOfMode, SHAKE + BIT_STRENGTH_256, BLOCK_SIZE_BIT_256, DIGEST_LENGTH_BIT_256)
+    ): super(null, null, xOfMode, SHAKE + BIT_STRENGTH_256, BLOCK_SIZE_BIT_256, outputLength)
 
     private constructor(state: DigestState, digest: SHAKE256): super(state, digest)
 
@@ -49,6 +62,6 @@ public class SHAKE256: SHAKEDigest {
          * Produces a new [Xof] (Extendable-Output Function) for [SHAKE256]
          * */
         @JvmStatic
-        public fun xOf(): Xof<SHAKE256> = SHAKEXof(SHAKE256(xOfMode = true))
+        public fun xOf(): Xof<SHAKE256> = SHAKEXof(SHAKE256(0, xOfMode = true))
     }
 }

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/SHAKEDigest.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/SHAKEDigest.kt
@@ -20,7 +20,6 @@ import org.kotlincrypto.core.internal.DigestState
 import org.kotlincrypto.endians.LittleEndian
 import org.kotlincrypto.endians.LittleEndian.Companion.toLittleEndian
 import org.kotlincrypto.sponges.keccak.F1600
-import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic
 
@@ -45,8 +44,7 @@ public sealed class SHAKEDigest: KeccakDigest, XofAlgorithm {
 
     private val initBlock: ByteArray?
     private var isReadingXof: Boolean
-    @JvmField
-    protected val xOfMode: Boolean
+    private val xOfMode: Boolean
 
     protected constructor(
         N: ByteArray?,
@@ -139,6 +137,11 @@ public sealed class SHAKEDigest: KeccakDigest, XofAlgorithm {
 
             init {
                 require(delegate.xOfMode) { "xOfMode must be true" }
+
+                // Some algorithms for the SHA3 derived functions require encoding
+                // the final output length before outputting data. While in XOF mode,
+                // the arbitrary output length, L, is represented as 0.
+                require(delegate.digestLength() == 0) { "digestLength must be 0" }
             }
 
             protected override fun newReader(delegateCopy: A): Xof<A>.Reader {
@@ -199,9 +202,9 @@ public sealed class SHAKEDigest: KeccakDigest, XofAlgorithm {
         internal const val BLOCK_SIZE_BIT_256 = 136
 
         // default digestLength for bitStrength of 128
-        internal const val DIGEST_LENGTH_BIT_128 = BIT_STRENGTH_128 / 4
+        internal const val DIGEST_LENGTH_BIT_128 = 32
         // default digestLength for bitStrength of 256
-        internal const val DIGEST_LENGTH_BIT_256 = BIT_STRENGTH_256 / 4
+        internal const val DIGEST_LENGTH_BIT_256 = 64
 
         /**
          * Given that [N] and [S] are both null and/or empty, CSHAKE is

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/TupleDigest.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/TupleDigest.kt
@@ -50,7 +50,7 @@ public sealed class TupleDigest: SHAKEDigest {
 
     protected final override fun digest(bitLength: Long, bufferOffset: Int, buffer: ByteArray): ByteArray {
         @OptIn(InternalKotlinCryptoApi::class)
-        val encL = Xof.Utils.rightEncode(if (xOfMode) 0L else digestLength() * 8L)
+        val encL = Xof.Utils.rightEncode(digestLength() * 8L)
 
         val size = bufferOffset + encL.size
         val newBitLength = bitLength + (encL.size * 8)

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/TupleHash128.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/TupleHash128.kt
@@ -31,19 +31,36 @@ import kotlin.jvm.JvmStatic
 public class TupleHash128: TupleDigest {
 
     /**
-     * Creates a new [TupleHash128] [Digest] instance with a fixed output
-     * [digestLength].
+     * Creates a new [TupleHash128] [Digest] instance with a default output
+     * length of 32 bytes.
      *
      * @param [S] A user selected customization bit string to define a variant
      *   of the function. When no customization is desired, [S] is set to an
      *   empty or null value. (e.g. "My Customization".encodeToByteArray())
      * */
-    public constructor(S: ByteArray?): this(S, xOfMode = false)
+    public constructor(S: ByteArray?): this(S, DIGEST_LENGTH_BIT_128)
+
+    /**
+     * Creates a new [TupleHash128] [Digest] instance with a non-default output
+     * length.
+     *
+     * @param [S] A user selected customization bit string to define a variant
+     *   of the function. When no customization is desired, [S] is set to an
+     *   empty or null value. (e.g. "My Customization".encodeToByteArray())
+     * @param [outputLength] The number of bytes returned when [digest] is invoked
+     * @throws [IllegalArgumentException] If [outputLength] is negative
+     * */
+    @Throws(IllegalArgumentException::class)
+    public constructor(
+        S: ByteArray?,
+        outputLength: Int,
+    ): this(S, outputLength, xOfMode = false)
 
     private constructor(
         S: ByteArray?,
+        outputLength: Int,
         xOfMode: Boolean,
-    ): super(S, xOfMode, BIT_STRENGTH_128, DIGEST_LENGTH_BIT_128)
+    ): super(S, xOfMode, BIT_STRENGTH_128, outputLength)
 
     private constructor(state: DigestState, digest: TupleHash128): super(state, digest)
 
@@ -60,6 +77,6 @@ public class TupleHash128: TupleDigest {
          * */
         @JvmStatic
         @JvmOverloads
-        public fun xOf(S: ByteArray? = null): Xof<TupleHash128> = SHAKEXof(TupleHash128(S, xOfMode = true))
+        public fun xOf(S: ByteArray? = null): Xof<TupleHash128> = SHAKEXof(TupleHash128(S, 0, xOfMode = true))
     }
 }

--- a/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/TupleHash256.kt
+++ b/library/sha3/src/commonMain/kotlin/org/kotlincrypto/hash/sha3/TupleHash256.kt
@@ -31,19 +31,36 @@ import kotlin.jvm.JvmStatic
 public class TupleHash256: TupleDigest {
 
     /**
-     * Creates a new [TupleHash256] [Digest] instance with a fixed output
-     * [digestLength].
+     * Creates a new [TupleHash256] [Digest] instance with a default output
+     * length of 64 bytes.
      *
      * @param [S] A user selected customization bit string to define a variant
      *   of the function. When no customization is desired, [S] is set to an
      *   empty or null value. (e.g. "My Customization".encodeToByteArray())
      * */
-    public constructor(S: ByteArray?): this(S, xOfMode = false)
+    public constructor(S: ByteArray?): this(S, DIGEST_LENGTH_BIT_256)
+
+    /**
+     * Creates a new [TupleHash256] [Digest] instance with a non-default output
+     * length.
+     *
+     * @param [S] A user selected customization bit string to define a variant
+     *   of the function. When no customization is desired, [S] is set to an
+     *   empty or null value. (e.g. "My Customization".encodeToByteArray())
+     * @param [outputLength] The number of bytes returned when [digest] is invoked
+     * @throws [IllegalArgumentException] If [outputLength] is negative
+     * */
+    @Throws(IllegalArgumentException::class)
+    public constructor(
+        S: ByteArray?,
+        outputLength: Int,
+    ): this(S, outputLength, xOfMode = false)
 
     private constructor(
         S: ByteArray?,
+        outputLength: Int,
         xOfMode: Boolean,
-    ): super(S, xOfMode, BIT_STRENGTH_256, DIGEST_LENGTH_BIT_256)
+    ): super(S, xOfMode, BIT_STRENGTH_256, outputLength)
 
     private constructor(state: DigestState, digest: TupleHash256): super(state, digest)
 
@@ -60,6 +77,6 @@ public class TupleHash256: TupleDigest {
          * */
         @JvmStatic
         @JvmOverloads
-        public fun xOf(S: ByteArray? = null): Xof<TupleHash256> = SHAKEXof(TupleHash256(S, xOfMode = true))
+        public fun xOf(S: ByteArray? = null): Xof<TupleHash256> = SHAKEXof(TupleHash256(S, 0, xOfMode = true))
     }
 }

--- a/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/SHAKEDigestUnitTest.kt
+++ b/library/sha3/src/commonTest/kotlin/org/kotlincrypto/hash/sha3/SHAKEDigestUnitTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.hash.sha3
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SHAKEDigestUnitTest {
+    
+    @Test
+    fun givenSHAKEDigest_whenLengthNonDefault_thenReturnsExpectedByteSize() {
+        // This exercises ALL inheritors of SHAKEDigest and how they will
+        // function with a non-default outputLength argument (i.e. digestLength)
+        SHAKE128(outputLength = 0).let { digest ->
+            assertEquals(0, digest.digestLength())
+            assertEquals(0, digest.digest().size)
+        }
+
+        SHAKE256(outputLength = 500).let { digest ->
+            assertEquals(500, digest.digestLength())
+            assertEquals(500, digest.digest().size)
+        }
+    }
+}


### PR DESCRIPTION
Closes #33 

This PR adds to all SHA3 `XOF` `Digest`s the ability to express a non-default output length (i.e. `digestLength`) configuration via constructor argument expression.